### PR TITLE
Recursive folder copy, separate update and copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ nobrowser.txt
 nocache.txt
 noverifyssl.txt
 gamcache/
+
+# Mac OS X specific
+.DS_Store

--- a/gam.py
+++ b/gam.py
@@ -716,7 +716,7 @@ def geturl(url, dst):
       status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
     else:
       status = r"%10d [unknown size]" % (file_size_dl)
-    status = status + chr(8)*(len(status)+1) 
+    status = status + chr(8)*(len(status)+1)
     print status,
   f.close()
 
@@ -2019,7 +2019,7 @@ def doCreateDriveFolder(user, title, parentid):
 
 
 def doCopyDriveFile(users):
-  convert = ocr = ocrLanguage = fileIds = parentid = None
+  convert = ocr = ocrLanguage = fileIds = parentid = newfilename = None
   recursive = False
   i = 5
   body = {}


### PR DESCRIPTION
## Major Changes
The largest change is the separation of the copy and update functions for drive files. The drive file copy implementation now exists in **doCopyDriveFile**

To support the new features, two new helper methods were added.
1. doRecursiveDriveCopy
2. doCreateDriveFolder

## Minor Changes
There may we a few trailing spaces trimmed by my editor settings.

Gitignore additions for OS X cruft.

## Command documentation

This change allows for drive folders to be copied recursively.

Example:
```
gam user user@example.com copy drivefile id 0B7K8EoFCAEZcdGpaFjFIcC1rTlE recursive
```

It also allows a file to be copied with a new name. If no new name is specified, the default "Copy of X" is used.

Example:
```
gam user user@example.com copy drivefile id 10q1TDk-56smOe-njLfZ-MX6BkOrNR_afeZI0DLUWd-s newfilename "New File Name"
```

Lastly, it allows for files or folders, to be copied into a specified parent.

Example:
```
gam user user@example.com copy drivefile id 0B7K8EoFCAEZcdGpaFjFIcC1rTlE recursive newfilename FolderName parentid 0B8K8EoCBAEZcZWTVc216c4Z4Rlk
```

### Testing
The project doesn't include tests as far as I can tell, but I tested all the copy functions and I made sure the doUpdateDriveFile continued to function as expected.