### PR TITLE
Change to showDriveFiles function to Allow Any Owner for Results

### DIFF
--- a/gam.py
+++ b/gam.py
@@ -2583,6 +2583,7 @@ def showDriveFiles(users):
   fields = u'nextPageToken,items(title,alternateLink'
   todrive = False
   query = u'"me" in owners'
+  user_query = ''
   i = 5
   labels = list()
   while i < len(sys.argv):
@@ -2590,8 +2591,11 @@ def showDriveFiles(users):
     if my_arg == u'todrive':
       todrive = True
       i += 1
+    elif my_arg == u'anyowner':
+      query = ''
+      i += 1
     elif my_arg == u'query':
-      query += u' and %s' % sys.argv[i+1]
+      user_query = sys.argv[i+1]
       i += 2
     elif my_arg == u'allfields':
       fields = u'*'
@@ -2656,6 +2660,11 @@ def showDriveFiles(users):
     else:
       print u'Error: %s is not a valid argument for "gam ... show filelist"' % my_arg
       sys.exit(3)
+  if len(user_query) > 0:
+      if len(query) > 0:
+        query = '%s and %s' % (query, user_query)
+      else:
+        query = user_query
   if len(labels) > 0:
     fields += ',labels(%s)' % ','.join(labels)
   if fields != u'*':

--- a/gam.py
+++ b/gam.py
@@ -2580,7 +2580,7 @@ def updateDriveFileACL(users):
 def showDriveFiles(users):
   files_attr = [{u'Owner': u'Owner',}]
   titles = [u'Owner',]
-  fields = u'nextPageToken,items(title,alternateLink'
+  fields = u'nextPageToken,items(title,owners,alternateLink'
   todrive = False
   query = u'"me" in owners'
   user_query = ''
@@ -2678,7 +2678,7 @@ def showDriveFiles(users):
     page_message = u' got %%%%total_items%%%% files for %s...\n' % user
     feed = callGAPIpages(service=drive.files(), function=u'list', page_message=page_message, soft_errors=True, q=query, maxResults=1000, fields=fields)
     for file in feed:
-      a_file = {u'Owner': user}
+      a_file = {u'Owner': file['owners'][0]['emailAddress']}
       for attrib in file.keys():
         if attrib in [u'kind', u'etags', u'etag', u'owners', 'parents']:
           continue


### PR DESCRIPTION
Small changes made to the showDriveFiles function to allow it to search for files outside of those owned by the user. This was made to allow Google Apps admins in our domain to be able to see what files are shared with particular users, what they only have editor rights to, etc. This functionality was requested by our security team. 

Additionally, setting the owner email address in the function output was changed from a static operation to being done dynamically based on the existing data returned by Google.

This 'anyowner' functionality can be utilized by simply adding the 'anyowner' flag into the existing command structure, and should have no impact on existing usage of the '... show filelist' command.