### PR TITLE
fix all user delete message iteration bug

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -344,6 +344,10 @@ def callGAPI(service, function, silent_errors=False, soft_errors=False, throw_re
     except googleapiclient.errors.HttpError, e:
       try:
         error = json.loads(e.content)
+        if (e.resp[u'status'] == u'400'):
+          if error['error']['message'] == u'Mail service not enabled':
+            print 'Error on current user; Mailbox not enabled. Skipping'
+            break
       except ValueError:
         if n < 3:
           disable_ssl_certificate_validation = False


### PR DESCRIPTION
When attempting to delete a message for all users, the process will
halt if we encounter a user with a mailbox that is not enabled. this
patch accounts for that case, and breaks out into the next user.

to repro; attempt to iterate through all users; where atleast one user has their mailbox disabled.

```
/gam.py all users delete messages query rfc822msgid:XXXXXXXXX@mail.gmail.com
```

if a mailbox is disabled, you will see:

```Error 400: Mail service not enabled - failedPrecondition``` 

and the script will halt.

This patch addresses this condition.
