### PR TITLE
Dynamic scopes update, other cleanup

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -239,7 +239,6 @@ GC_VAR_INFO = {
   GC_USER_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'GAM_USER_MAX_RESULTS', GC_VAR_LIMITS_KEY: (1, 500)},
   }
 
-
 MESSAGE_BATCH_CSV_DASH_DEBUG_INCOMPATIBLE = u'"gam {0} - ..." is not compatible with debugging. Disable debugging by deleting debug.gam and try again.'
 MESSAGE_CLIENT_API_ACCESS_DENIED = u'Access Denied. Please make sure the Client Name:\n\n{0}\n\nis authorized for the API Scope(s):\n\n{1}\n\nThis can be configured in your Control Panel under:\n\nSecurity -->\nAdvanced Settings -->\nManage API client access'
 MESSAGE_GAMSCOPES_JSON_INVALID = u'The file {0} is missing the required key (scopes) or has an invalid format.'
@@ -518,13 +517,13 @@ def SetGlobalVariables():
   GM_Globals[GM_OAUTH2SERVICE_KEY] = None
   GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_EMAIL] = None
   GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_CLIENT_ID] = None
-  if GC_Values[GC_NO_CACHE]:
-    GC_Values[GC_CACHE_DIR] = None
   json_string = readFile(GC_Values[GC_GAMSCOPES_JSON], continueOnError=True, displayError=False)
   if json_string and not validateSetGAMScopes(json.loads(json_string)):
     systemErrorExit(19, MESSAGE_GAMSCOPES_JSON_INVALID.format(GC_Values[GC_GAMSCOPES_JSON]))
   _chkCfgDirectories()
   _chkCfgFiles()
+  if GC_Values[GC_NO_CACHE]:
+    GC_Values[GC_CACHE_DIR] = None
   return True
 
 def doGAMCheckForUpdates(forceCheck=False):

--- a/src/gam.py
+++ b/src/gam.py
@@ -242,7 +242,7 @@ GC_VAR_INFO = {
 MESSAGE_BATCH_CSV_DASH_DEBUG_INCOMPATIBLE = u'"gam {0} - ..." is not compatible with debugging. Disable debugging by deleting debug.gam and try again.'
 MESSAGE_CLIENT_API_ACCESS_CONFIG = u'API access is configured in your Control Panel under: Security-Show more-Advanced settings-Manage API client access'
 MESSAGE_CLIENT_API_ACCESS_DENIED = u'API access denied. Please make sure the service account ID: {0} is authorized for the API Scope(s): {1}'
-MESSAGE_GAMSCOPES_JSON_INVALID = u'The file {0} is missing the required key (scopes) or has an invalid format.'
+MESSAGE_GAMSCOPES_JSON_INVALID = u'The file {0} has an invalid format.'
 MESSAGE_GAM_EXITING_FOR_UPDATE = u'GAM is now exiting so that you can overwrite this old version with the latest release'
 MESSAGE_GAM_OUT_OF_MEMORY = u'GAM has run out of memory. If this is a large Google Apps instance, you should use a 64-bit version of GAM on Windows or a 64-bit version of Python on other systems.'
 MESSAGE_HEADER_NOT_FOUND_IN_CSV_HEADERS = u'Header "{0}" not found in CSV headers of "{1}".'
@@ -8852,8 +8852,8 @@ def doRequestOAuth():
     print
     print u'     %2d) Select defaults for all APIs (allow all GAM commands)' % (i)
     print u'     %2d) Unselect all APIs' % (i+1)
-    print u'     %2d) Continue' % (i+2)
-    print u'     %2d) Cancel' % (i+3)
+    print u'     %2d) Cancel' % (i+2)
+    print u'     %2d) Continue' % (i+3)
     print
     selection = getSelection(i+3)
     if selection == i: # defaults
@@ -8861,7 +8861,7 @@ def doRequestOAuth():
     elif selection == i+1: # unselect all
       for api in all_apis.keys():
         all_apis[api][u'use_scopes'] = []
-    elif selection == i+2: # continue
+    elif selection == i+3: # continue
       GM_Globals[GM_GAMSCOPES_BY_API] = {}
       GM_Globals[GM_GAMSCOPES_LIST] = []
       for api in all_apis.keys():
@@ -8874,7 +8874,7 @@ def doRequestOAuth():
       writeFile(GC_Values[GC_GAMSCOPES_JSON], json.dumps(GM_Globals[GM_GAMSCOPES_BY_API]))
       print u'Scopes file: {0}, Created'.format(GC_Values[GC_GAMSCOPES_JSON])
       break
-    elif selection == i+3: # cancel
+    elif selection == i+2: # cancel
       return
     else: # select
       api = all_apis.keys()[selection]
@@ -8882,7 +8882,7 @@ def doRequestOAuth():
         if len(all_apis[api][u'use_scopes']) == 1:
           all_apis[api][u'use_scopes'] = []
         else:
-          all_apis[api][u'use_scopes'] = all_apis[api][u'auth'][u'oauth2'][u'scopes']
+          all_apis[api][u'use_scopes'] = all_apis[api][u'auth'][u'oauth2'][u'scopes'].keys()
       else:
         while True:
           os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
@@ -8898,8 +8898,8 @@ def doRequestOAuth():
           print u'     %2d) Select defaults for this API (allow all GAM commands)' % (x)
           print u'     %2d) Select read-only scopes' % (x+1)
           print u'     %2d) Unselect all scopes' % (x+2)
-          print u'     %2d) Back to all APIs' % (x+3)
-          print u'     %2d) Cancel' % (x+4)
+          print u'     %2d) Cancel' % (x+3)
+          print u'     %2d) Back to all APIs' % (x+4)
           print
           selection = getSelection(x+4)
           if selection < x: # select
@@ -8918,7 +8918,7 @@ def doRequestOAuth():
                 all_apis[api][u'use_scopes'].append(scope)
           elif selection == x+2: # unselect all
             all_apis[api][u'use_scopes'] = []
-          elif selection == x+3: # back
+          elif selection == x+4: # back
             break
           else: # cancel
             return

--- a/src/gam.py
+++ b/src/gam.py
@@ -506,6 +506,10 @@ def SetGlobalVariables():
   GM_Globals[GM_LAST_UPDATE_CHECK_TXT] = os.path.join(GC_Values[GC_CONFIG_DIR], FN_LAST_UPDATE_CHECK_TXT)
   if not GC_Values[GC_NO_UPDATE_CHECK]:
     doGAMCheckForUpdates()
+  if (not GC_Values[GC_DOMAIN]) and GC_Values[GC_ADMIN]:
+    loc = GC_Values[GC_ADMIN].find(u'@')
+    if loc > 0:
+      GC_Values[GC_DOMAIN] = GC_Values[GC_ADMIN][loc+1:]
 # Globals derived from config file values
   GM_Globals[GM_EXTRA_ARGS_DICT] = {u'prettyPrint': GC_Values[GC_DEBUG_LEVEL] > 0}
   httplib2.debuglevel = GC_Values[GC_DEBUG_LEVEL]

--- a/src/gam.py
+++ b/src/gam.py
@@ -95,8 +95,6 @@ GM_GAMSCOPES_BY_API = u'scop'
 GM_GAMSCOPES_LIST = u'scof'
 # Current API scope
 GM_CURRENT_API_SCOPES = u'scoc'
-# gamscopes.json created
-GM_GAMSCOPES_CREATED = u'gscr'
 # Values retrieved from oauth2service.json
 GM_OAUTH2SERVICE_KEY = u'oauk'
 GM_OAUTH2SERVICE_ACCOUNT_EMAIL = u'oaae'
@@ -122,7 +120,6 @@ GM_Globals = {
   GM_GAMSCOPES_BY_API: {},
   GM_GAMSCOPES_LIST: [],
   GM_CURRENT_API_SCOPES: [],
-  GM_GAMSCOPES_CREATED: False,
   GM_OAUTH2SERVICE_KEY: None,
   GM_OAUTH2SERVICE_ACCOUNT_EMAIL:  None,
   GM_OAUTH2SERVICE_ACCOUNT_CLIENT_ID: None,
@@ -174,16 +171,8 @@ GC_NO_VERIFY_SSL = u'no_verify_ssl'
 GC_NUM_THREADS = u'num_threads'
 # Path to oauth2service.json
 GC_OAUTH2SERVICE_JSON = u'oauth2service_json'
-# Default section to use for processing
-GC_SECTION = u'section'
-# Add (n/m) to end of messages if number of items to be processed exceeds this number
-GC_SHOW_COUNTS_MIN = u'show_counts_min'
-# Enable/disable "Getting ... " messages
-GC_SHOW_GETTINGS = u'show_gettings'
 # GAM config directory containing admin-settings-v1.json, cloudprint-v2.json
 GC_SITE_DIR = u'site_dir'
-# When adding Users to Groups/Org Units, how many should be processed in each batch
-GC_USER_BATCH_SIZE = u'user_batch_size'
 # When retrieving lists of Users from API, how many should be retrieved in each chunk
 GC_USER_MAX_RESULTS = u'user_max_results'
 
@@ -207,11 +196,7 @@ GC_Defaults = {
   GC_NO_VERIFY_SSL: FALSE,
   GC_NUM_THREADS: 5,
   GC_OAUTH2SERVICE_JSON: FN_OAUTH2SERVICE_JSON,
-  GC_SECTION: u'',
-  GC_SHOW_COUNTS_MIN: 1,
-  GC_SHOW_GETTINGS: TRUE,
   GC_SITE_DIR: u'',
-  GC_USER_BATCH_SIZE: 50,
   GC_USER_MAX_RESULTS: 500,
   }
 
@@ -227,35 +212,33 @@ GC_TYPE_LANGUAGE = u'lang'
 GC_TYPE_STRING = u'stri'
 
 GC_VAR_TYPE_KEY = u'type'
+GC_VAR_ENVVAR_KEY = u'enva'
 GC_VAR_LIMITS_KEY = u'lmit'
 
 GC_VAR_INFO = {
-  GC_ACTIVITY_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (1, 500)},
-  GC_ADMIN: {GC_VAR_TYPE_KEY: GC_TYPE_STRING},
-  GC_AUTO_BATCH_MIN: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (0, None)},
-  GC_CACHE_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY},
-  GC_CHARSET: {GC_VAR_TYPE_KEY: GC_TYPE_STRING},
-  GC_CONFIG_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY},
-  GC_CUSTOMER_ID: {GC_VAR_TYPE_KEY: GC_TYPE_STRING},
-  GC_DEBUG_LEVEL: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (0, None)},
-  GC_DEVICE_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (1, 1000)},
-  GC_DOMAIN: {GC_VAR_TYPE_KEY: GC_TYPE_STRING},
-  GC_DRIVE_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY},
-  GC_DRIVE_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (1, 1000)},
-  GC_GAMSCOPES_JSON: {GC_VAR_TYPE_KEY: GC_TYPE_FILE},
-  GC_NO_BROWSER: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN},
-  GC_NO_CACHE: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN},
-  GC_NO_UPDATE_CHECK: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN},
-  GC_NO_VERIFY_SSL: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN},
-  GC_NUM_THREADS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (1, None)},
-  GC_OAUTH2SERVICE_JSON: {GC_VAR_TYPE_KEY: GC_TYPE_FILE},
-  GC_SECTION: {GC_VAR_TYPE_KEY: GC_TYPE_STRING},
-  GC_SHOW_COUNTS_MIN: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (0, None)},
-  GC_SHOW_GETTINGS: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN},
-  GC_SITE_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY},
-  GC_USER_BATCH_SIZE: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (1, 1000)},
-  GC_USER_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_LIMITS_KEY: (1, 500)},
+  GC_ACTIVITY_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'GAM_ACTIVITY_MAX_RESULTS', GC_VAR_LIMITS_KEY: (1, 500)},
+  GC_ADMIN: {GC_VAR_TYPE_KEY: GC_TYPE_STRING, GC_VAR_ENVVAR_KEY: u'GAM_ADMIN'},
+  GC_AUTO_BATCH_MIN: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'GAM_AUTOBATCH', GC_VAR_LIMITS_KEY: (0, None)},
+  GC_CACHE_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY, GC_VAR_ENVVAR_KEY: u'GAMCACHEDIR'},
+  GC_CHARSET: {GC_VAR_TYPE_KEY: GC_TYPE_STRING, GC_VAR_ENVVAR_KEY: u'GAM_CHARSET'},
+  GC_CONFIG_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY, GC_VAR_ENVVAR_KEY: u'GAMUSERCONFIGDIR'},
+  GC_CUSTOMER_ID: {GC_VAR_TYPE_KEY: GC_TYPE_STRING, GC_VAR_ENVVAR_KEY: u'CUSTOMER_ID'},
+  GC_DEBUG_LEVEL: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'debug.gam', GC_VAR_LIMITS_KEY: (0, None)},
+  GC_DEVICE_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'GAM_DEVICE_MAX_RESULTS', GC_VAR_LIMITS_KEY: (1, 1000)},
+  GC_DOMAIN: {GC_VAR_TYPE_KEY: GC_TYPE_STRING, GC_VAR_ENVVAR_KEY: u'GA_DOMAIN'},
+  GC_DRIVE_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY, GC_VAR_ENVVAR_KEY: u'GAMDRIVEDIR'},
+  GC_DRIVE_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'GAM_DRIVE_MAX_RESULTS', GC_VAR_LIMITS_KEY: (1, 1000)},
+  GC_GAMSCOPES_JSON: {GC_VAR_TYPE_KEY: GC_TYPE_FILE, GC_VAR_ENVVAR_KEY: u'GAMSCOPESFILE'},
+  GC_NO_BROWSER: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN, GC_VAR_ENVVAR_KEY: u'nobrowser.txt'},
+  GC_NO_CACHE: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN, GC_VAR_ENVVAR_KEY: u'nocache.txt'},
+  GC_NO_UPDATE_CHECK: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN, GC_VAR_ENVVAR_KEY: u'noupdatecheck.txt'},
+  GC_NO_VERIFY_SSL: {GC_VAR_TYPE_KEY: GC_TYPE_BOOLEAN, GC_VAR_ENVVAR_KEY: u'noverifyssl.txt'},
+  GC_NUM_THREADS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'GAM_THREADS', GC_VAR_LIMITS_KEY: (1, None)},
+  GC_OAUTH2SERVICE_JSON: {GC_VAR_TYPE_KEY: GC_TYPE_FILE, GC_VAR_ENVVAR_KEY: u'OAUTHSERVICEFILE'},
+  GC_SITE_DIR: {GC_VAR_TYPE_KEY: GC_TYPE_DIRECTORY, GC_VAR_ENVVAR_KEY: u'GAMSITECONFIGDIR'},
+  GC_USER_MAX_RESULTS: {GC_VAR_TYPE_KEY: GC_TYPE_INTEGER, GC_VAR_ENVVAR_KEY: u'GAM_USER_MAX_RESULTS', GC_VAR_LIMITS_KEY: (1, 500)},
   }
+
 
 MESSAGE_BATCH_CSV_DASH_DEBUG_INCOMPATIBLE = u'"gam {0} - ..." is not compatible with debugging. Disable debugging by deleting debug.gam and try again.'
 MESSAGE_CLIENT_API_ACCESS_DENIED = u'Access Denied. Please make sure the Client Name:\n\n{0}\n\nis authorized for the API Scope(s):\n\n{1}\n\nThis can be configured in your Control Panel under:\n\nSecurity -->\nAdvanced Settings -->\nManage API client access'
@@ -441,8 +424,8 @@ def writeFile(filename, data, mode=u'wb', continueOnError=False, displayError=Tr
 #
 def SetGlobalVariables():
 
-  def _getOldEnvVar(itemName, envVar):
-    value = os.environ.get(envVar, GC_Defaults[itemName])
+  def _getOldEnvVar(itemName):
+    value = os.environ.get(GC_VAR_INFO[itemName][GC_VAR_ENVVAR_KEY], GC_Defaults[itemName])
     if GC_VAR_INFO[itemName][GC_VAR_TYPE_KEY] == GC_TYPE_INTEGER:
       try:
         number = int(value)
@@ -456,8 +439,8 @@ def SetGlobalVariables():
       value = number
     GC_Defaults[itemName] = value
 
-  def _getOldSignalFile(itemName, fileName, trueValue=True, falseValue=False):
-    GC_Defaults[itemName] = trueValue if os.path.isfile(os.path.join(GC_Defaults[GC_CONFIG_DIR], fileName)) else falseValue
+  def _getOldSignalFile(itemName, trueValue=True, falseValue=False):
+    GC_Defaults[itemName] = trueValue if os.path.isfile(os.path.join(GC_Defaults[GC_CONFIG_DIR], GC_VAR_INFO[itemName][GC_VAR_ENVVAR_KEY])) else falseValue
 
   def _getCfgDirectory(itemName):
     return GC_Defaults[itemName]
@@ -468,34 +451,48 @@ def SetGlobalVariables():
       value = os.path.expanduser(os.path.join(GC_Values[GC_CONFIG_DIR], value))
     return value
 
+  def _chkCfgDirectories():
+    for itemName in GC_VAR_INFO:
+      if GC_VAR_INFO[itemName][GC_VAR_TYPE_KEY] == GC_TYPE_DIRECTORY:
+        dirPath = GC_Values[itemName]
+        if not os.path.isdir(dirPath):
+          sys.stderr.write(u'{0}{1}={2}, Invalid Path\n'.format(WARNING_PREFIX, GC_VAR_INFO[itemName][GC_VAR_ENVVAR_KEY], dirPath))
+
+  def _chkCfgFiles():
+    for itemName in GC_VAR_INFO:
+      if GC_VAR_INFO[itemName][GC_VAR_TYPE_KEY] == GC_TYPE_FILE:
+        fileName = GC_Values[itemName]
+        if not os.path.isfile(fileName):
+          sys.stderr.write(u'{0}{1}={2}, Not Found\n'.format(WARNING_PREFIX, GC_VAR_INFO[itemName][GC_VAR_ENVVAR_KEY], fileName))
+
   GC_Defaults[GC_CONFIG_DIR] = GM_Globals[GM_GAM_PATH]
   GC_Defaults[GC_CACHE_DIR] = os.path.join(GM_Globals[GM_GAM_PATH], u'gamcache')
   GC_Defaults[GC_DRIVE_DIR] = GM_Globals[GM_GAM_PATH]
   GC_Defaults[GC_SITE_DIR] = GM_Globals[GM_GAM_PATH]
 
-  _getOldEnvVar(GC_CONFIG_DIR, u'GAMUSERCONFIGDIR')
-  _getOldEnvVar(GC_SITE_DIR, u'GAMSITECONFIGDIR')
-  _getOldEnvVar(GC_CACHE_DIR, u'GAMCACHEDIR')
-  _getOldEnvVar(GC_DRIVE_DIR, u'GAMDRIVEDIR')
-  _getOldEnvVar(GC_OAUTH2SERVICE_JSON, u'OAUTHSERVICEFILE')
+  _getOldEnvVar(GC_CONFIG_DIR)
+  _getOldEnvVar(GC_SITE_DIR)
+  _getOldEnvVar(GC_CACHE_DIR)
+  _getOldEnvVar(GC_DRIVE_DIR)
+  _getOldEnvVar(GC_OAUTH2SERVICE_JSON)
   if GC_Defaults[GC_OAUTH2SERVICE_JSON].find(u'.') == -1:
     GC_Defaults[GC_OAUTH2SERVICE_JSON] += u'.json'
-  _getOldEnvVar(GC_GAMSCOPES_JSON, u'GAMSCOPESFILE')
-  _getOldEnvVar(GC_DOMAIN, u'GA_DOMAIN')
-  _getOldEnvVar(GC_ADMIN, u'GAM_ADMIN')
-  _getOldEnvVar(GC_CUSTOMER_ID, u'CUSTOMER_ID')
-  _getOldEnvVar(GC_CHARSET, u'GAM_CHARSET')
-  _getOldEnvVar(GC_NUM_THREADS, u'GAM_THREADS')
-  _getOldEnvVar(GC_AUTO_BATCH_MIN, u'GAM_AUTOBATCH')
-  _getOldEnvVar(GC_ACTIVITY_MAX_RESULTS, u'GAM_ACTIVITY_MAX_RESULTS')
-  _getOldEnvVar(GC_DEVICE_MAX_RESULTS, u'GAM_DEVICE_MAX_RESULTS')
-  _getOldEnvVar(GC_DRIVE_MAX_RESULTS, u'GAM_DRIVE_MAX_RESULTS')
-  _getOldEnvVar(GC_USER_MAX_RESULTS, u'GAM_USER_MAX_RESULTS')
-  _getOldSignalFile(GC_DEBUG_LEVEL, u'debug.gam', trueValue=4, falseValue=0)
-  _getOldSignalFile(GC_NO_VERIFY_SSL, u'noverifyssl.txt')
-  _getOldSignalFile(GC_NO_BROWSER, u'nobrowser.txt')
-  _getOldSignalFile(GC_NO_CACHE, u'nocache.txt')
-  _getOldSignalFile(GC_NO_UPDATE_CHECK, u'noupdatecheck.txt')
+  _getOldEnvVar(GC_GAMSCOPES_JSON)
+  _getOldEnvVar(GC_DOMAIN)
+  _getOldEnvVar(GC_ADMIN)
+  _getOldEnvVar(GC_CUSTOMER_ID)
+  _getOldEnvVar(GC_CHARSET)
+  _getOldEnvVar(GC_NUM_THREADS)
+  _getOldEnvVar(GC_AUTO_BATCH_MIN)
+  _getOldEnvVar(GC_ACTIVITY_MAX_RESULTS)
+  _getOldEnvVar(GC_DEVICE_MAX_RESULTS)
+  _getOldEnvVar(GC_DRIVE_MAX_RESULTS)
+  _getOldEnvVar(GC_USER_MAX_RESULTS)
+  _getOldSignalFile(GC_DEBUG_LEVEL, trueValue=4, falseValue=0)
+  _getOldSignalFile(GC_NO_VERIFY_SSL)
+  _getOldSignalFile(GC_NO_BROWSER)
+  _getOldSignalFile(GC_NO_CACHE)
+  _getOldSignalFile(GC_NO_UPDATE_CHECK)
 # Assign directories first
   for itemName in GC_VAR_INFO:
     if GC_VAR_INFO[itemName][GC_VAR_TYPE_KEY] == GC_TYPE_DIRECTORY:
@@ -510,9 +507,6 @@ def SetGlobalVariables():
   if not GC_Values[GC_NO_UPDATE_CHECK]:
     doGAMCheckForUpdates()
 # Globals derived from config file values
-  GM_Globals[GM_OAUTH2SERVICE_KEY] = None
-  GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_EMAIL] = None
-  GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_CLIENT_ID] = None
   GM_Globals[GM_EXTRA_ARGS_DICT] = {u'prettyPrint': GC_Values[GC_DEBUG_LEVEL] > 0}
   httplib2.debuglevel = GC_Values[GC_DEBUG_LEVEL]
   if os.path.isfile(os.path.join(GC_Values[GC_CONFIG_DIR], FN_EXTRA_ARGS_TXT)):
@@ -521,14 +515,16 @@ def SetGlobalVariables():
     ea_config.optionxform = str
     ea_config.read(os.path.join(GC_Values[GC_CONFIG_DIR], FN_EXTRA_ARGS_TXT))
     GM_Globals[GM_EXTRA_ARGS_DICT].update(dict(ea_config.items(u'extra-args')))
+  GM_Globals[GM_OAUTH2SERVICE_KEY] = None
+  GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_EMAIL] = None
+  GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_CLIENT_ID] = None
   if GC_Values[GC_NO_CACHE]:
     GC_Values[GC_CACHE_DIR] = None
-  GM_Globals[GM_GAMSCOPES_CREATED] = False
-  json_string = readFile(GC_Values[GC_GAMSCOPES_JSON], continueOnError=True, displayError=True)
-  if not json_string:
-    doRequestOAuth()
-  elif not validateSetGAMScopes(json.loads(json_string)):
+  json_string = readFile(GC_Values[GC_GAMSCOPES_JSON], continueOnError=True, displayError=False)
+  if json_string and not validateSetGAMScopes(json.loads(json_string)):
     systemErrorExit(19, MESSAGE_GAMSCOPES_JSON_INVALID.format(GC_Values[GC_GAMSCOPES_JSON]))
+  _chkCfgDirectories()
+  _chkCfgFiles()
   return True
 
 def doGAMCheckForUpdates(forceCheck=False):
@@ -8731,8 +8727,11 @@ def doDeleteOAuth():
   time.sleep(1)
   sys.stdout.write(u'boom!\n')
   sys.stdout.flush()
-  os.remove(GC_Values[GC_GAMSCOPES_JSON])
-  sys.stdout.write(u'Scopes file: {0}, Deleted\n'.format(GC_Values[GC_GAMSCOPES_JSON]))
+  try:
+    os.remove(GC_Values[GC_GAMSCOPES_JSON])
+    sys.stdout.write(u'Scopes file: {0}, Deleted\n'.format(GC_Values[GC_GAMSCOPES_JSON]))
+  except OSError as e:
+    sys.stderr.write(u'{0}{1}\n'.format(WARNING_PREFIX, e))
 
 UBER_SCOPES = {
   u'gmail-v1': [u'https://mail.google.com/'],
@@ -8824,7 +8823,6 @@ def doRequestOAuth():
         continue
       writeFile(GC_Values[GC_GAMSCOPES_JSON], json.dumps(GM_Globals[GM_GAMSCOPES_BY_API]))
       print u'Scopes file: {0}, Created'.format(GC_Values[GC_GAMSCOPES_JSON])
-      GM_Globals[GM_GAMSCOPES_CREATED] = True
       break
     elif selection >= 0 and selection < len(all_apis.keys()):
       api = all_apis.keys()[selection]
@@ -9250,8 +9248,7 @@ try:
     sys.exit(0)
   elif sys.argv[1].lower() in [u'oauth', u'oauth2']:
     if sys.argv[2].lower() in [u'request', u'create']:
-      if not GM_Globals[GM_GAMSCOPES_CREATED]:
-        doRequestOAuth()
+      doRequestOAuth()
     elif sys.argv[2].lower() == u'info':
       OAuthInfo()
     elif sys.argv[2].lower() in [u'delete', u'revoke']:

--- a/src/gam.py
+++ b/src/gam.py
@@ -8799,6 +8799,14 @@ def select_default_scopes(apis):
       apis[api_name][u'use_scopes'] += scopes
   return apis
 
+def getSelection():
+  while True:
+    selection = raw_input(u'Your selection: ')
+    if selection:
+      if selection.isdigit():
+        return int(selection)
+      print u'ERROR: please enter numbers only'
+
 def doRequestOAuth():
   apis = API_VER_MAPPING.keys()
   all_apis = {}
@@ -8821,8 +8829,8 @@ def doRequestOAuth():
   if GM_Globals[GM_GAMSCOPES_BY_API]:
     for api in GM_Globals[GM_GAMSCOPES_BY_API]:
       all_apis[api][u'use_scopes'] = GM_Globals[GM_GAMSCOPES_BY_API][api][u'use_scopes']
-  os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
   while True:
+    os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
     print u'Select the APIs to use with GAM.'
     print
     for api in all_apis.values():
@@ -8838,8 +8846,8 @@ def doRequestOAuth():
     print u'     %s) Unselect all APIs' % (i+2)
     print u'     %s) Continue' % (i+3)
     print
-    selection = int(raw_input(u'Your selection: '))
-    if int(selection) == i+1: # defaults
+    selection = getSelection()
+    if selection == i+1: # defaults
       all_apis = select_default_scopes(all_apis)
     elif selection == i+2: # unselect all
       for api in all_apis.keys():
@@ -8865,8 +8873,8 @@ def doRequestOAuth():
         else:
           all_apis[api][u'use_scopes'] = all_apis[api][u'auth'][u'oauth2'][u'scopes']
       else:
-        os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
         while True:
+          os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
           print
           x = 0
           for scope in all_apis[api][u'auth'][u'oauth2'][u'scopes'].keys():
@@ -8881,12 +8889,7 @@ def doRequestOAuth():
           print u'     %s) Unselect all scopes' % (x+2)
           print u'     %s) Back to all APIs' % (x+3)
           print
-          selection = raw_input(u'Your selection: ')
-          try:
-            selection = int(selection)
-          except:
-            print u'ERROR: please enter numbers only'
-            continue
+          selection = getSelection()
           num_scopes = len(all_apis[api][u'auth'][u'oauth2'][u'scopes'].keys())
           if selection >= 0 and selection < num_scopes:
             if all_apis[api][u'auth'][u'oauth2'][u'scopes'].keys()[selection] in all_apis[api][u'use_scopes']:
@@ -8906,8 +8909,6 @@ def doRequestOAuth():
             all_apis[api][u'use_scopes'] = []
           elif selection == x+3:
             break
-          os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
-      os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
   print MESSAGE_PLEASE_AUTHORIZE_SERVIE_ACCOUNT.format(len(GM_Globals[GM_GAMSCOPES_LIST]))
   print
   print u','.join(GM_Globals[GM_GAMSCOPES_LIST])
@@ -9282,7 +9283,7 @@ try:
   elif sys.argv[1].lower() in [u'oauth', u'oauth2']:
     if sys.argv[2].lower() in [u'request', u'create']:
       doRequestOAuth()
-    elif sys.argv[2].lower() == u'info':
+    elif sys.argv[2].lower() in [u'info', u'verify']:
       OAuthInfo()
     elif sys.argv[2].lower() in [u'delete', u'revoke']:
       doDeleteOAuth()

--- a/src/gam.py
+++ b/src/gam.py
@@ -121,7 +121,7 @@ GM_Globals = {
   GM_EXTRA_ARGS_DICT:  {u'prettyPrint': False},
   GM_GAMSCOPES_BY_API: {},
   GM_GAMSCOPES_LIST: [],
-  GM_CURRENT_API_SCOPES: None,
+  GM_CURRENT_API_SCOPES: [],
   GM_GAMSCOPES_CREATED: False,
   GM_OAUTH2SERVICE_KEY: None,
   GM_OAUTH2SERVICE_ACCOUNT_EMAIL:  None,
@@ -269,6 +269,7 @@ MESSAGE_NO_PYTHON_SSL = u'You don\'t have the Python SSL module installed so we 
 MESSAGE_NO_SCOPES_FOR_API = u'There are no scopes authorized for API {0}-{1}; please run gam oauth create'
 MESSAGE_NO_TRANSFER_LACK_OF_DISK_SPACE = u'Cowardly refusing to perform migration due to lack of target drive space. Source size: {0}mb Target Free: {1}mb'
 MESSAGE_OAUTH2SERVICE_JSON_INVALID = u'The file {0} is missing required keys (client_email, client_id or private_key).'
+MESSAGE_PLEASE_AUTHORIZE_SERVIE_ACCOUNT = u'Please authorize your service account client id for the {} scopes:'
 MESSAGE_REQUEST_COMPLETED_NO_FILES = u'Request completed but no results/files were returned, try requesting again'
 MESSAGE_REQUEST_NOT_COMPLETE = u'Request needs to be completed before downloading, current status is: {0}'
 MESSAGE_RESULTS_TOO_LARGE_FOR_GOOGLE_SPREADSHEET = u'Results are too large for Google Spreadsheets. Uploading as a regular CSV file.'
@@ -527,7 +528,7 @@ def SetGlobalVariables():
   if not json_string:
     doRequestOAuth()
   elif not validateSetGAMScopes(json.loads(json_string)):
-    systemErrorExit(17, MESSAGE_GAMSCOPES_JSON_INVALID.format(GC_Values[GC_GAMSCOPES_JSON]))
+    systemErrorExit(19, MESSAGE_GAMSCOPES_JSON_INVALID.format(GC_Values[GC_GAMSCOPES_JSON]))
   return True
 
 def doGAMCheckForUpdates(forceCheck=False):
@@ -583,7 +584,7 @@ def doGAMVersion():
 def tryOAuth(gdataObject, soft_errors=False):
   credentials = oauth2client.client.SignedJwtAssertionCredentials(GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_EMAIL],
                                                                   GM_Globals[GM_OAUTH2SERVICE_KEY],
-                                                                  scope=GM_Globals[GM_GAMSCOPES_LIST], user_agent=GAM_INFO, sub=GC_Values[GC_ADMIN])
+                                                                  scope=GM_Globals[GM_CURRENT_API_SCOPES], user_agent=GAM_INFO, sub=GC_Values[GC_ADMIN])
   http = httplib2.Http(disable_ssl_certificate_validation=GC_Values[GC_NO_VERIFY_SSL],
                        cache=GC_Values[GC_CACHE_DIR])
   try:
@@ -846,7 +847,7 @@ def buildGAPIObject(api, act_as=None, soft_errors=False):
   setCurrentAPIScopes(api, version)
   credentials = oauth2client.client.SignedJwtAssertionCredentials(GM_Globals[GM_OAUTH2SERVICE_ACCOUNT_EMAIL],
                                                                   GM_Globals[GM_OAUTH2SERVICE_KEY],
-                                                                  scope=GM_Globals[GM_GAMSCOPES_LIST], user_agent=GAM_INFO, sub=sub)
+                                                                  scope=GM_Globals[GM_CURRENT_API_SCOPES], user_agent=GAM_INFO, sub=sub)
   http = credentials.authorize(httplib2.Http(disable_ssl_certificate_validation=GC_Values[GC_NO_VERIFY_SSL],
                                              cache=GC_Values[GC_CACHE_DIR]))
   try:
@@ -8788,7 +8789,7 @@ def doRequestOAuth():
   if GM_Globals[GM_GAMSCOPES_BY_API]:
     for api in GM_Globals[GM_GAMSCOPES_BY_API]:
       all_apis[api][u'use_scopes'] = GM_Globals[GM_GAMSCOPES_BY_API][api][u'use_scopes']
-  os.system([u'clear', u'cls'][os.name == u'nt'])
+  os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
   while True:
     print u'Select the APIs to use with GAM.'
     print
@@ -8833,7 +8834,7 @@ def doRequestOAuth():
         else:
           all_apis[api][u'use_scopes'] = all_apis[api][u'auth'][u'oauth2'][u'scopes']
       else:
-        os.system([u'clear', u'cls'][os.name == u'nt'])
+        os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
         while True:
           print
           x = 0
@@ -8874,9 +8875,9 @@ def doRequestOAuth():
             all_apis[api][u'use_scopes'] = []
           elif selection == x+3:
             break
-          os.system([u'clear', u'cls'][os.name == u'nt'])
-      os.system([u'clear', u'cls'][os.name == u'nt'])
-  print u'Please authorize your service account client id for the %s scopes:' % (len(GM_Globals[GM_GAMSCOPES_LIST]))
+          os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
+      os.system([u'clear', u'cls'][GM_Globals[GM_WINDOWS]])
+  print MESSAGE_PLEASE_AUTHORIZE_SERVIE_ACCOUNT.format(len(GM_Globals[GM_GAMSCOPES_LIST]))
   print
   print u','.join(GM_Globals[GM_GAMSCOPES_LIST])
 

--- a/src/gam.py
+++ b/src/gam.py
@@ -4812,12 +4812,12 @@ def getSignature(users):
       user = user[:user.find(u'@')]
     else:
       emailsettings.domain = GC_Values[GC_DOMAIN]
-    signature = callGData(emailsettings, u'GetSignature', soft_errors=True, username=user)
-    try:
-      sys.stderr.write(u"User %s signature:\n  " % (user+u'@'+emailsettings.domain))
-      print convertUTF8(u" %s" % signature[u'signature'])
-    except TypeError:
-      pass
+    result = callGData(emailsettings, u'GetSignature', soft_errors=True, username=user)
+    signature = result.get(u'signature', u'None') if result else u'None'
+    if not signature:
+      signature = u'None'
+    sys.stdout.write(u"User %s signature:\n  " % (user+u'@'+emailsettings.domain))
+    print convertUTF8(u" %s" % signature)
 
 def doWebClips(users):
   if sys.argv[4].lower() in true_values:


### PR DESCRIPTION
I have testing scripts that, for instance, print everything that can be printed. Under the old client/service account model, this always worked fine. Now, after a few commands, I'm getting "ERROR: invalid_request: Rate limit exceeded". Are service accounts under a different set of rate restrictions?

Update. This seemed to be resolved when I went back to the API specific scope lists. I was also getting internal errors with the full scope list of 32 scopes. What won't work with the API specific scope lists?