### PR TITLE
Clean up, fixes

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -402,7 +402,10 @@ def readFile(filename, mode=u'rb', continueOnError=False, displayError=True, enc
           return f.read()
       else:
         with codecs.open(filename, mode, encoding) as f:
-          return f.read()
+          content = f.read()
+          if not content.startswith(codecs.BOM_UTF8):
+            return content
+          return content.replace(codecs.BOM_UTF8, u'', 1)
     else:
       return unicode(sys.stdin.read())
   except IOError as e:

--- a/src/gam.py
+++ b/src/gam.py
@@ -4471,7 +4471,7 @@ def labelsToLabelIds(gmail, labels):
     if label not in allLabels:
       # first refresh labels in user mailbox
       label_results = callGAPI(gmail.users().labels(), 'list',
-        userId='me', fields='labels(name,id,type)')
+                               userId='me', fields='labels(name,id,type)')
       for a_label in label_results['labels']:
         if a_label['type'] == 'system':
           allLabels[a_label['id']] = a_label['id']
@@ -4479,9 +4479,9 @@ def labelsToLabelIds(gmail, labels):
           allLabels[a_label['name']] = a_label['id']
     if label not in allLabels:
       # if still not there, create it
-      label_results = callGAPI(service=gmail.users().labels(), function='create',
-        body={'labelListVisibility': 'labelShow',
-        'messageListVisibility': 'show', 'name': label},
+      label_results = callGAPI(gmail.users().labels(), 'create',
+                               body={'labelListVisibility': 'labelShow',
+                                     'messageListVisibility': 'show', 'name': label},
         userId='me', fields='id')
       allLabels[label] = label_results['id']
     try:
@@ -4493,8 +4493,8 @@ def labelsToLabelIds(gmail, labels):
       parent_label = label[:label.rfind('/')]
       while True:
         if not parent_label in allLabels:
-          label_result = callGAPI(service=gmail.users().labels(),
-            function='create', userId='me', body={'name': parent_label})
+          label_result = callGAPI(service=gmail.users().labels(), 'create',
+                                  userId='me', body={'name': parent_label})
           allLabels[parent_label] = label_result['id']
         if parent_label.find('/') == -1:
           break

--- a/src/oauth2client/tools.py
+++ b/src/oauth2client/tools.py
@@ -215,11 +215,8 @@ def run_flow(flow, storage, flags=None, http=None):
         print()
         print('    ' + authorize_url)
         print()
-        print('If your browser is on a different machine then '
-              'exit and re-run this')
-        print('application with the command-line parameter ')
-        print()
-        print('  --noauth_local_webserver')
+        print('If your browser is on a different machine then exit and re-run this')
+        print('after creating a file called nobrowser.txt in the same path as GAM.')
         print()
     else:
         print('Go to the following link in your browser:')


### PR DESCRIPTION
Bump version

Clean up label processing
- doLabel: cosmetic
- labelsToLabelIds: cosmetic
- doDeleteLabel: downshift argument label once, use for/break/else to clean up code
- updateLabels: downshift argument label once, use for/break/else to clean up code

buildGAPIServiceObject
- cache oauth2service.json data so file isn't repeatedly read
- handle exceptions from oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_dict
- fix typo in error message

Handle extended characters when reading signature and vacation files
- readFile: take encoding parameter
- doSignature, doVacation: specify encoding to readFile

doProcessMessages
- clean up coding relating to body
- simplify addlabel/removelabel error handling
- move kwargs code after delete processing