### PR TITLE
Remove underscore or the string will not match

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -8862,7 +8862,7 @@ def doPrintUsers():
     elif myarg == u'todrive':
       todrive = True
       i += 1
-    elif myarg in [u'deleted_only', u'only_deleted']:
+    elif myarg in [u'deletedonly', u'onlydeleted']:
       deleted_only = True
       i += 1
     elif myarg == u'orderby':


### PR DESCRIPTION
The argument is stripped of any underscore:
    `8843     myarg = sys.argv[i].lower().replace(u'_', u'')`

we must also remove the underscore from here or they will not match:
    `elif myarg in [u'deleted_only', u'only_deleted']:`
