### PR TITLE
Version

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -416,7 +416,7 @@ def indentMultiLineText(message, n=0):
   return message.replace(u'\n', u'\n{0}'.format(u' '*n)).rstrip()
 
 def showUsage():
-  doGAMVersion()
+  doGAMVersion(checkForCheck=False)
   print u'''
 Usage: gam [OPTIONS]...
 


### PR DESCRIPTION
Use string version rather than float.
This lets you have 3.72.0 or 3.72a; current scheme continues to work as well.

Add check to gam version  so user can determine if they're on latest version.
$ gam version check
GAM 3.72 - http://git.io/gam
Jay Lee <jay0lee@gmail.com>
Python 2.7.12 64-bit final
google-api-python-client 1.5.2
Darwin-15.6.0-x86_64-i386-64bit x86_64
Path: /Users/admin/Documents/GoogleApps/GAM
Version: Check, Current: 3.72, Latest: 3.71
$
Note that latest version at appspot is behind.

Handle bad data in lastupdatecheck.txt

