### PR TITLE
Update NL handling in doSignature and doVacation

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -6102,9 +6102,9 @@ def doSignature(users):
   if sys.argv[i].lower() == u'file':
     filename = sys.argv[i+1]
     i, encoding = getCharSet(i+2)
-    signature = readFile(filename, encoding=encoding).replace(u'\\n', u'<br/>').replace(u'\n', u'<br/>')
+    signature = readFile(filename, encoding=encoding).replace(u'\\n', u'<br/>')
   else:
-    signature = getString(i, u'String', emptyOK=True).replace(u'\\n', u'<br/>').replace(u'\n', u'<br/>')
+    signature = getString(i, u'String', emptyOK=True).replace(u'\\n', u'<br/>')
     i += 1
   body = {}
   while i < len(sys.argv):
@@ -6200,7 +6200,7 @@ def doVacation(users):
         sys.exit(2)
     if message:
       if responseBodyType == u'responseBodyHtml':
-        message = message.replace(u'\\n', u'<br/>').replace(u'\n', u'<br/>')
+        message = message.replace(u'\\n', u'<br/>')
       else:
         message = message.replace(u'\\n', u'\n')
       if tagReplacements:


### PR DESCRIPTION
Converting all NLs to `<br/>` causes extra blank lines when a multi-line HTML file is specified.
Google seems to handle the straight NLs appropriately.
My versions do it this way and I've gotten no complaints.