### PR TITLE
Added html argument to gam add sendas/update sendas/signature

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -792,14 +792,14 @@ gam <UserTypeEntity> show imap|imap4
 gam <UserTypeEntity> pop|pop3 <Boolean> [for allmail|newmail|mailfromnowon|fromnowown] [action keep|leaveininbox|archive|delete|trash|markread]
 gam <UserTypeEntity> show pop|pop3
 
-gam <UserTypeEntity> [add] sendas <EmailAddress> <Name> [signature|sig <String>|(file <FileName> [charset <CharSet>]) (replace <Tag> <String>)*] [replyto <EmailAddress>] [default] [treatasalias <Boolean>]
-gam <UserTypeEntity> update sendas <EmailAddress> [name <Name>] [signature|sig <String>|(file <FileName> [charset <CharSet>]) (replace <Tag> <String>)*] [replyto <EmailAddress>] [default] [treatasalias <Boolean>]
+gam <UserTypeEntity> [add] sendas <EmailAddress> <Name> [signature|sig <String>|(file <FileName> [charset <CharSet>]) (replace <Tag> <String>)*] [html] [replyto <EmailAddress>] [default] [treatasalias <Boolean>]
+gam <UserTypeEntity> update sendas <EmailAddress> [name <Name>] [signature|sig <String>|(file <FileName> [charset <CharSet>]) (replace <Tag> <String>)*] [html] [replyto <EmailAddress>] [default] [treatasalias <Boolean>]
 gam <UserTypeEntity> delete sendas <EmailAddress>
 gam <UserTypeEntity> show sendas [format]
 gam <UserTypeEntity> info sendas <EmailAddress> [format]
 gam <UserTypeEntity> print sendas [todrive]
 
-gam <UserTypeEntity> signature|sig <String>|(file <FileName> [charset <Charset>]) (replace <Tag> <String>)* [name <String>] [replyto <EmailAddress>] [default] [treatasalias <Boolean>]
+gam <UserTypeEntity> signature|sig <String>|(file <FileName> [charset <Charset>]) (replace <Tag> <String>)* [html] [name <String>] [replyto <EmailAddress>] [default] [treatasalias <Boolean>]
 gam <UserTypeEntity> show signature|sig [format]
 
 gam <UserTypeEntity> vacation <FalseValues>

--- a/src/gam.py
+++ b/src/gam.py
@@ -5061,6 +5061,7 @@ def addUpdateSendAs(users, i, addCmd):
     body = {}
   signature = None
   tagReplacements = {}
+  html = False
   while i < len(sys.argv):
     myarg = sys.argv[i].lower()
     if myarg in [u'signature', u'sig']:
@@ -5069,16 +5070,21 @@ def addUpdateSendAs(users, i, addCmd):
       if signature == u'file':
         filename = sys.argv[i]
         i, encoding = getCharSet(i+1)
-        signature = readFile(filename, encoding=encoding)
+        signature = readFile(filename, encoding=encoding).replace(u'\\n', u'<br/>')
+      else:
+        signature = signature.replace(u'\\n', u'<br/>')
+    elif myarg == u'html':
+      html = True
+      i += 1
     else:
       i = getSendAsAttributes(i, myarg, body, tagReplacements, command)
   if signature is not None:
-    if not signature:
-      body[u'signature'] = None
-    elif tagReplacements:
-      body[u'signature'] = _processTags(tagReplacements, signature)
-    else:
-      body[u'signature'] = signature
+    if signature:
+      if tagReplacements:
+        signature = _processTags(tagReplacements, signature)
+      if not html:
+        signature = signature.replace(u'\n', u'<br/>')
+    body[u'signature'] = signature
   kwargs = {u'body': body}
   if not addCmd:
     kwargs[u'sendAsEmail'] = emailAddress
@@ -6107,13 +6113,20 @@ def doSignature(users):
     signature = getString(i, u'String', emptyOK=True).replace(u'\\n', u'<br/>')
     i += 1
   body = {}
+  html = False
   while i < len(sys.argv):
     myarg = sys.argv[i].lower()
-    i = getSendAsAttributes(i, myarg, body, tagReplacements, u'signature')
-  if tagReplacements:
-    body[u'signature'] = _processTags(tagReplacements, signature)
-  else:
-    body[u'signature'] = signature
+    if myarg == u'html':
+      html = True
+      i += 1
+    else:
+      i = getSendAsAttributes(i, myarg, body, tagReplacements, u'signature')
+  if signature:
+    if tagReplacements:
+      signature = _processTags(tagReplacements, signature)
+    if not html:
+      signature = signature.replace(u'\n', u'<br/>')
+  body[u'signature'] = signature
   i = 0
   count = len(users)
   for user in users:


### PR DESCRIPTION
Google led me astray. If you include plain NLs in a signature, the NLs are returned by Google to Gam in show signature, everything looks OK. However, the NLs are not included in the signature when it is included in an email.

Added html argument to gam add sendas/update sendas/signature to control newline (NL) processing when signature is read from a file.
When `html` is not specified, newlines are converted to `<br/>`; this allows simple, multi-line files to be interpreted properly by Google.
When `html` is specified, newlines are not converted to `<br/>`; this allows multi-line HTML files to be interpreted properly by Google, no extra blank lines will be included.

The default behavior will be as before, NLs are converted to `<br/>`. Users that are uploading HTML signatures will use the `html` argument to suppress the conversion.
