### PR TITLE
Added count and allfields arguments to gam print groups

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -585,8 +585,8 @@ gam info group <GroupItem> [nousers] [noaliases] [groups]
 gam update group <GroupItem> clear [member] [manager] [owner]
 
 gam print groups [todrive] ([domain <DomainName>] [member <UserItem>])
-	[maxresults <Number>] [delimiter <String>]
-	[members] [managers] [owners] [settings] <GroupFieldName>* [fields <GroupFieldNameList>]
+	[maxresults <Number>] [allfields|([settings] <GroupFieldName>* [fields <GroupFieldNameList>])] [delimiter <String>]
+	[members|memberscount] [managers|managerscount] [owners|ownerscount]
 
 gam print group-members|groups-members [todrive] ([domain <DomainName>] [member <UserItem>])|[group <GroupItem>]
 	[membernames] [fields <MembersFieldNameList>]

--- a/src/gam.py
+++ b/src/gam.py
@@ -9092,7 +9092,7 @@ GROUP_ATTRIBUTES_ARGUMENT_TO_PROPERTY_MAP = {
 def doPrintGroups():
   cd = buildGAPIObject(u'directory')
   i = 3
-  members = owners = managers = False
+  members = membersCountOnly = managers = managersCountOnly = owners = ownersCountOnly = False
   customer = GC_Values[GC_CUSTOMER_ID]
   usedomain = usemember = None
   aliasDelimiter = u' '
@@ -9106,7 +9106,7 @@ def doPrintGroups():
   addFieldTitleToCSVfile(u'email', GROUP_ARGUMENT_TO_PROPERTY_TITLE_MAP, cdfieldsList, fieldsTitles, titles)
   maxResults = None
   roles = []
-  getSettings = False
+  getSettings = sortHeaders = False
   while i < len(sys.argv):
     myarg = sys.argv[i].lower()
     if myarg == u'todrive':
@@ -9129,6 +9129,17 @@ def doPrintGroups():
     elif myarg in GROUP_ARGUMENT_TO_PROPERTY_TITLE_MAP:
       addFieldTitleToCSVfile(myarg, GROUP_ARGUMENT_TO_PROPERTY_TITLE_MAP, cdfieldsList, fieldsTitles, titles)
       i += 1
+    elif myarg == u'settings':
+      getSettings = True
+      i += 1
+    elif myarg == u'allfields':
+      getSettings = sortHeaders = True
+      cdfieldsList = []
+      gsfieldsList = []
+      fieldsTitles = {}
+      for field in GROUP_ARGUMENT_TO_PROPERTY_TITLE_MAP:
+        addFieldTitleToCSVfile(field, GROUP_ARGUMENT_TO_PROPERTY_TITLE_MAP, cdfieldsList, fieldsTitles, titles)
+      i += 1
     elif myarg == u'fields':
       fieldNameList = sys.argv[i+1]
       for field in fieldNameList.lower().replace(u',', u' ').split():
@@ -9141,26 +9152,23 @@ def doPrintGroups():
           print u'ERROR: %s is not a valid argument for "gam print groups fields"' % field
           sys.exit(2)
       i += 2
-    elif myarg == u'members':
-      if myarg not in roles:
-        roles.append(ROLE_MEMBER)
-        addTitleToCSVfile(u'Members', titles)
-        members = True
+    elif myarg in [u'members', u'memberscount']:
+      roles.append(ROLE_MEMBER)
+      members = True
+      if myarg == u'memberscount':
+        membersCountOnly = True
       i += 1
-    elif myarg == u'owners':
-      if myarg not in roles:
-        roles.append(ROLE_OWNER)
-        addTitleToCSVfile(u'Owners', titles)
-        owners = True
+    elif myarg in [u'owners', u'ownerscount']:
+      roles.append(ROLE_OWNER)
+      owners = True
+      if myarg == u'ownerscount':
+        ownersCountOnly = True
       i += 1
-    elif myarg == u'managers':
-      if myarg not in roles:
-        roles.append(ROLE_MANAGER)
-        addTitleToCSVfile(u'Managers', titles)
-        managers = True
-      i += 1
-    elif myarg == u'settings':
-      getSettings = True
+    elif myarg in [u'managers', u'managerscount']:
+      roles.append(ROLE_MANAGER)
+      managers = True
+      if myarg == u'managerscount':
+        managersCountOnly = True
       i += 1
     else:
       print u'ERROR: %s is not a valid argument for "gam print groups"' % sys.argv[i]
@@ -9174,6 +9182,19 @@ def doPrintGroups():
   if getSettings:
     gs = buildGAPIObject(u'groupssettings')
   roles = u','.join(sorted(set(roles)))
+  if roles:
+    if members:
+      addTitlesToCSVfile([u'MembersCount',], titles)
+      if not membersCountOnly:
+        addTitlesToCSVfile([u'Members',], titles)
+    if managers:
+      addTitlesToCSVfile([u'ManagersCount',], titles)
+      if not managersCountOnly:
+        addTitlesToCSVfile([u'Managers',], titles)
+    if owners:
+      addTitlesToCSVfile([u'OwnersCount',], titles)
+      if not ownersCountOnly:
+        addTitlesToCSVfile([u'Owners',], titles)
   sys.stderr.write(u"Retrieving All Groups for G Suite account (may take some time on a large account)...\n")
   page_message = u'Got %%num_items%% groups: %%first_item%% - %%last_item%%\n'
   entityList = callGAPIpages(cd.groups(), u'list', u'groups',
@@ -9200,11 +9221,14 @@ def doPrintGroups():
                                    page_message=page_message, message_attribute=u'email',
                                    groupKey=groupEmail, roles=roles, fields=u'nextPageToken,members(email,id,role)')
       if members:
-        allMembers = list()
+        membersList = []
+        membersCount = 0
       if managers:
-        allManagers = list()
+        managersList = []
+        managersCount = 0
       if owners:
-        allOwners = list()
+        ownersList = []
+        ownersCount = 0
       for member in groupMembers:
         member_email = member.get(u'email', member.get(u'id', None))
         if not member_email:
@@ -9214,23 +9238,39 @@ def doPrintGroups():
         if role:
           if role == ROLE_MEMBER:
             if members:
-              allMembers.append(member_email)
+              membersCount += 1
+              if not membersCountOnly:
+                membersList.append(member_email)
           elif role == ROLE_MANAGER:
             if managers:
-              allManagers.append(member_email)
+              managersCount += 1
+              if not managersCountOnly:
+                managersList.append(member_email)
           elif role == ROLE_OWNER:
             if owners:
-              allOwners.append(member_email)
+              ownersCount += 1
+              if not ownersCountOnly:
+                ownersList.append(member_email)
           elif members:
-            allMembers.append(member_email)
+            membersCount += 1
+            if not membersCountOnly:
+              membersList.append(member_email)
         elif members:
-          allMembers.append(member_email)
+          membersCount += 1
+          if not membersCountOnly:
+            membersList.append(member_email)
       if members:
-        group[u'Members'] = memberDelimiter.join(allMembers)
+        group[u'MembersCount'] = membersCount
+        if not membersCountOnly:
+          group[u'Members'] = memberDelimiter.join(membersList)
       if managers:
-        group[u'Managers'] = memberDelimiter.join(allManagers)
+        group[u'ManagersCount'] = managersCount
+        if not managersCountOnly:
+          group[u'Managers'] = memberDelimiter.join(managersList)
       if owners:
-        group[u'Owners'] = memberDelimiter.join(allOwners)
+        group[u'OwnersCount'] = ownersCount
+        if not ownersCountOnly:
+          group[u'Owners'] = memberDelimiter.join(ownersList)
     if getSettings and not GroupIsAbuseOrPostmaster(groupEmail):
       sys.stderr.write(u" Retrieving Settings for group %s (%s/%s)...\r\n" % (groupEmail, i, count))
       settings = callGAPI(gs.groups(), u'get',
@@ -9250,6 +9290,8 @@ def doPrintGroups():
       else:
         sys.stderr.write(u" Settings unavailable for group %s (%s/%s)...\r\n" % (groupEmail, i, count))
     csvRows.append(group)
+  if sortHeaders:
+    sortCSVTitles([u'Email',], titles)
   writeCSVfile(csvRows, titles, u'Groups', todrive)
 
 ORG_ARGUMENT_TO_PROPERTY_TITLE_MAP = {


### PR DESCRIPTION
Added memberscount, managerscount and ownerscount arguments to gam print groups; they cause the number of members/managers/owners to be shown, not the list of email addresses.

When members/managers/owners are specified, there will be two columns per role: Members,MembersCount,Managers,ManagersCount,Owners,OwnersCount
When memberscount/managerscount/ownerscount are specified, there will be one column per role: MembersCount,ManagersCount,OwnersCount

Added allfields argument to gam print groups; this selects all of the basic group settings and all of the extended groups settings; the columns will be sorted when allfields is specified with Email remaining as the leftmost column.
```
gam print groups [todrive] ([domain <DomainName>] [member <UserItem>])
        [maxresults <Number>] [allfields|([settings] <GroupFieldName>* [fields <GroupFieldNameList>])] [convertcrnl] [delimiter <String>]
        [members|memberscount] [managers|managerscount] [owners|ownerscount]
```