### PR TITLE
Allow suppression of empty entries in multivalued schema fields

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -6169,7 +6169,8 @@ def getUserAttributes(i, cd, updateCmd=False):
       body.setdefault(up, {})
       body[up].setdefault(schemaName, {})
       i += 1
-      if sys.argv[i].lower() in [u'multivalue', u'multivalued', u'value']:
+      multivalue = sys.argv[i].lower()
+      if multivalue in [u'multivalue', u'multivalued', u'value', u'multinonempty']:
         i += 1
         body[up][schemaName].setdefault(fieldName, [])
         schemaValue = {}
@@ -6184,7 +6185,8 @@ def getUserAttributes(i, cd, updateCmd=False):
             schemaValue[u'customType'] = sys.argv[i]
             i += 1
         schemaValue[u'value'] = sys.argv[i]
-        body[up][schemaName][fieldName].append(schemaValue)
+        if schemaValue[u'value'] or multivalue != u'multinonempty':
+          body[up][schemaName][fieldName].append(schemaValue)
       else:
         body[up][schemaName][fieldName] = sys.argv[i]
       i += 1


### PR DESCRIPTION
`gam csv users.csv gam update user "~User" Schema.Field multinonempty "~MultiValue1" Schema.Field multinonempty "~MultiValue2"`
If columns MultiValue1 or MultiValue2 are empty, they will not be added.
