### PR TITLE
Enhance print courses/course-participants

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -128,6 +128,25 @@ Named items
 <URL> ::= <String>
 <UserItem> ::= <EmailAddress>|<UniqueID>|<String>
 
+<CourseFieldName> ::=
+	alternatelink|
+	coursegroupemail|
+	coursematerialsets|
+	coursestate|
+	creationtime|
+	description|
+	descriptionheading|
+	enrollmentcode|
+	guardiansenabled|
+	id|
+	name|
+	ownerid|
+	room|
+	section|
+	teacherfolder|
+	teachergroupemail|
+	updatetime
+<CourseFieldNameList> ::= '<CourseFieldName>(,<CourseFieldName>)*'
 
 <CrOSFieldName> ::=
 	activetimeranges|timeranges|
@@ -644,6 +663,7 @@ gam update course <CourseID> <CourseAttributes>+
 gam delete course <CourseID>
 gam info course <CourseID>
 gam print courses [todrive] [teacher <UserItem>] [student <UserItem>] [alias|aliases] [delimiter <String>]
+	[show all|students|teachers] [fields <CourseFieldNameList>] [skipfields <CourseFieldNameList>]
 
 gam course <CourseID> add alias <CourseAlias>
 gam course <CourseID> delete alias <CourseAlias>


### PR DESCRIPTION
```
gam print courses [todrive] [teacher <UserItem>] [student <UserItem>] [alias|aliases] [delimiter <String>]
        [show all|students|teachers] [fields <CourseFieldNameList>] [skipfields <CourseFieldNameList>]
gam print course-participants [todrive] (course|class <CourseID>)*|([teacher <UserItem>] [student <UserItem>])
        [show all|students|teachers]
```
By default, print courses doesn't show any teachers/students and print course-participants shows both; this matches current behavior.

`gam print courses show teachers` will give you course details and teachers on one row.
`gam print courses skipfields coursematerialsets` will give you something manageable when CourseMaterialSets are being used.