### PR TITLE
Fix handling of ~skuId from CSV files

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -121,6 +121,7 @@ Named items
 <RoleAssignmentID> ::= <String>
 <SchemaName> ::= <String>
 <Section> ::= <String>
+<S/MIMEID> ::= <String>	
 <StudentItem> ::= <EmailAddress>|<UniqueID>|<String>
 <Timezone> ::= <String>
 <Title> ::= <String>
@@ -515,6 +516,27 @@ gam <UserTypeEntity> check serviceaccount
 
 gam whatis <EmailItem>
 
+gam create resoldcustomer <CustomerDomain> (customer_auth_token <String>)
+	(email|alternate_email <EmailAddress>) (name|organization_name <String>) (contact|contact_name <String>) [phone|phone_number <String>]
+	[address|address1 <String>] [address2 <String>] [address3 <String>]
+	[locality|city <String>] [region|state <String>] [postal|postal_code <String>] [country|country_code <String>]
+gam update resoldcustomer <CustomerID> [customer_auth_token <String>]
+	[email|alternate_email <EmailAddress>] [name|organization_name <String>] [contact|contact_name <String>] [phone|phone_number <String>]
+	[address|address1 <String>] [address2 <String>] [address3 <String>]
+	[locality|city <String>] [region|state <String>] [postal|postal_code <String>] [country|country_code <String>]
+gam info resoldcustomer <CustomerID>
+
+gam create resoldsubscription <CustomerID>
+	 [customer_auth_token <String>] [plan annual_monthly_pay|annual_yearly_pay|flexible|trial]
+	 [deal <String>] [purchaseorderid <String>] [seats <NumberOfSeats> <MaximumNumberOfSeats>] [sku <SKUID>]
+gam update resoldsubscription <CustomerID> <SKUID>
+	activate|suspend|startpaidservice|
+	(renewal auto_renew_monthly_pay|auto_renew_yearly_pay|cancel|renew_current_users_monthly_pay|renew_current_users_yearly_pay|switch_to_pay_as_you_go)|
+	(seats <NumberOfSeats> [<MaximumNumberOfSeats>])|
+	(plan annual_monthly_pay|annual_yearly_pay|flexible|trial [deal <String>] [purchaseorderid <String>] [seats <NumberOfSeats> [<MaximumNumberOfSeats>]])
+gam delete resoldsubscription <CustomerID> <SKUID> cancel|downgrade|transfer_to_direct
+gam info resoldsubscriptions <CustomerID> [customer_auth_token <String>]
+
 gam report users|user [todrive]
 	[date <Date>] [(user all|<UserItem>)] [filter|filters <String>] [fields|parameters <String>]
 gam report customers|customer|domain [todrive]
@@ -825,8 +847,8 @@ gam <UserTypeEntity> info sendas <EmailAddress> [format]
 gam <UserTypeEntity> print sendas [todrive]
 
 gam <UserTypeEntity> add smime file <FileName> [password <Password>] [sendas|sendasemail <EmailAddress>] [default]
-gam <UserTypeEntity> update smime [id <SmimeID>] [sendas|sendasemail <EmailAddress>] [default]
-gam <UserTypeEntity> delete smime [id <SmimeID>] [sendas|sendasemail <EmailAddress>]
+gam <UserTypeEntity> update smime [id <S/MIMEID>] [sendas|sendasemail <EmailAddress>] [default]
+gam <UserTypeEntity> delete smime [id <S/MIMEID>] [sendas|sendasemail <EmailAddress>]
 gam <UserTypeEntity> show smime [primaryonly]
 gam <UserTypeEntity> print smime [todrive] [primaryonly]
 

--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -824,6 +824,12 @@ gam <UserTypeEntity> show sendas [format]
 gam <UserTypeEntity> info sendas <EmailAddress> [format]
 gam <UserTypeEntity> print sendas [todrive]
 
+gam <UserTypeEntity> add smime file <FileName> [password <Password>] [sendas|sendasemail <EmailAddress>] [default]
+gam <UserTypeEntity> update smime [id <SmimeID>] [sendas|sendasemail <EmailAddress>] [default]
+gam <UserTypeEntity> delete smime [id <SmimeID>] [sendas|sendasemail <EmailAddress>]
+gam <UserTypeEntity> show smime [primaryonly]
+gam <UserTypeEntity> print smime [todrive] [primaryonly]
+
 gam <UserTypeEntity> signature|sig <String>|(file <FileName> [charset <Charset>]) (replace <Tag> <String>)* [html] [name <String>] [replyto <EmailAddress>] [default] [treatasalias <Boolean>]
 gam <UserTypeEntity> show signature|sig [format]
 

--- a/src/gam.py
+++ b/src/gam.py
@@ -7398,7 +7398,7 @@ def _getResoldSubscriptionAttr(arg, customerId):
       body[u'purchaseOrderId'] = arg[i+1]
     elif myarg in [u'seats']:
       body[u'seats'][u'numberOfSeats'] = arg[i+1]
-      if len(arg) > i + 1 and arg[i+2].isdigit():
+      if len(arg) > i + 2 and arg[i+2].isdigit():
         body[u'seats'][u'maximumNumberOfSeats'] = arg[i+2]
         i += 1
     elif myarg in [u'sku', u'skuid']:

--- a/src/gam.py
+++ b/src/gam.py
@@ -7399,6 +7399,7 @@ def _getResoldSubscriptionAttr(arg, customerId):
       body[u'seats'][u'numberOfSeats'] = arg[i+1]
       if len(arg) > i + 1 and arg[i+2].isdigit():
         body[u'seats'][u'maximumNumberOfSeats'] = arg[i+2]
+        i += 1
     elif myarg in [u'sku', u'skuid']:
       _, body[u'skuId'] = getProductAndSKU(arg[i+1])
     elif myarg in [u'customerauthtoken', u'transfertoken']:
@@ -7464,7 +7465,7 @@ def doCreateResoldCustomer():
   res = buildGAPIObject(u'reseller')
   customerAuthToken, body = _getResoldCustomerAttr(sys.argv[4:])
   body[u'customerDomain'] = sys.argv[3]
-  result = callGAPI(res.customers(), u'insert', body=body, customerAuthToken=customerAuthToken, fields=u'customerId')
+  result = callGAPI(res.customers(), u'insert', body=body, customerAuthToken=customerAuthToken, fields=u'customerId,customerDomain')
   print u'Created customer %s with id %s' % (result[u'customerDomain'], result[u'customerId'])
 
 def doGetUserInfo(user_email=None):

--- a/src/gam.py
+++ b/src/gam.py
@@ -4351,18 +4351,14 @@ def getImap(users):
         print u'User: {0}, IMAP Enabled: {1} ({2}/{3})'.format(user, enabled, i, count)
 
 def getProductAndSKU(sku):
-  product = None
   l_sku = sku.lower().replace(u'-', u'').replace(u' ', u'')
   for a_sku, sku_values in SKUS.items():
     if l_sku == a_sku.lower().replace(u'-', u'') or l_sku in sku_values[u'aliases'] or l_sku == sku_values[u'displayName'].lower().replace(u' ', u''):
-      sku = a_sku
-      product = sku_values[u'product']
-      break
-  if not product:
-    try:
-      product = re.search(u'^([A-Z,a-z]*-[A-Z,a-z]*)', sku).group(1)
-    except AttributeError:
-      product = sku
+      return (sku_values[u'product'], a_sku)
+  try:
+    product = re.search(u'^([A-Z,a-z]*-[A-Z,a-z]*)', sku).group(1)
+  except AttributeError:
+    product = sku
   return (product, sku)
 
 def doLicense(users, operation):

--- a/src/gam.py
+++ b/src/gam.py
@@ -7356,10 +7356,10 @@ def doUpdateResoldSubscription():
           kwargs[u'body'][u'dealCode'] = sys.argv[i+1]
           i += 2
         else:
-          print u'ERROR: %s is not a valid argument to "gam update resoldcustomer plan"' % planarg
+          print u'ERROR: %s is not a valid argument to "gam update resoldsubscription plan"' % planarg
           sys.exit(3)
     else:
-      print u'ERROR: %s is not a valid argument to "gam <users> update resoldsubscription"' % myarg
+      print u'ERROR: %s is not a valid argument to "gam update resoldsubscription"' % myarg
   result = callGAPI(res.subscriptions(), function, customerId=customerId, subscriptionId=subscriptionId, **kwargs)
   print u'Updated %s SKU %s subscription:' % (customerId, sku)
   if result:
@@ -7376,7 +7376,7 @@ def doGetResoldSubscriptions():
       customerAuthToken = sys.argv[i+1]
       i += 2
     else:
-      print u'ERROR: %s is not a valid argument for "gam show resoldsubscriptions"' % myarg
+      print u'ERROR: %s is not a valid argument for "gam info resoldsubscriptions"' % myarg
       sys.exit(3)
   result = callGAPI(res.subscriptions(), u'list', customerId=customerId, customerAuthToken=customerAuthToken)
   print_json(None, result)
@@ -7447,7 +7447,7 @@ def _getResoldCustomerAttr(arg):
     elif myarg in [u'customerauthtoken', u'transfertoken']:
       customerAuthToken = arg[i+1]
     else:
-      print u'ERROR: %s is not a valid argument for resoldcustomer' % myarg
+      print u'ERROR: %s is not a valid argument for "gam %s resoldcustomer"' % (myarg, sys.argv[1])
       sys.exit(3)
     i += 2
   if not body[u'postalAddress']:

--- a/src/gam.py
+++ b/src/gam.py
@@ -7353,7 +7353,7 @@ def doUpdateResoldSubscription():
           kwargs[u'body'][u'purchaseOrderId'] = sys.argv[i+1]
           i += 2
         elif planarg in [u'dealcode', u'deal']:
-          kwargs[u'body'][u'dealCode']
+          kwargs[u'body'][u'dealCode'] = sys.argv[i+1]
           i += 2
         else:
           print u'ERROR: %s is not a valid argument to "gam update resoldcustomer plan"' % planarg

--- a/src/gam.py
+++ b/src/gam.py
@@ -10180,9 +10180,9 @@ def ProcessGAMCommand(args):
         except IndexError:
           login_hint = None
         doCreateProject(login_hint)
-      elif argument in [u'resoldcustomer']:
+      elif argument in [u'resoldcustomer', u'resellercustomer']:
         doCreateResoldCustomer()
-      elif argument in [u'resoldsubscription', u'subscription']:
+      elif argument in [u'resoldsubscription', u'resellersubscription']:
         doCreateResoldSubscription()
       else:
         print u'ERROR: %s is not a valid argument for "gam create"' % argument
@@ -10314,7 +10314,7 @@ def ProcessGAMCommand(args):
         except IndexError:
           login_hint = None
         doDelProjects(login_hint)
-      elif argument in [u'resoldsubscription']:
+      elif argument in [u'resoldsubscription', u'resellersubscription']:
         doDeleteResoldSubscription()
       else:
         print u'ERROR: %s is not a valid argument for "gam delete"' % argument

--- a/src/gam.py
+++ b/src/gam.py
@@ -7360,6 +7360,7 @@ def doUpdateResoldSubscription():
           sys.exit(3)
     else:
       print u'ERROR: %s is not a valid argument to "gam update resoldsubscription"' % myarg
+      sys.exit(3)
   result = callGAPI(res.subscriptions(), function, customerId=customerId, subscriptionId=subscriptionId, **kwargs)
   print u'Updated %s SKU %s subscription:' % (customerId, sku)
   if result:
@@ -7372,7 +7373,7 @@ def doGetResoldSubscriptions():
   i = 4
   while i < len(sys.argv):
     myarg = sys.argv[i].lower().replace(u'_', u'')
-    if myarg in [u'customer_auth_token', u'transfer_token']:
+    if myarg in [u'customerauthtoken', u'transfertoken']:
       customerAuthToken = sys.argv[i+1]
       i += 2
     else:


### PR DESCRIPTION
As the display name of SKUs is being written to CSV files, it has to be accepted on input

In print users, the skuIds values need to be separated by something other that space as the display names have spaces in them

I'm wondering if writing the display names to the CSV files is going to break existing users scripts. In print licenses, we could leave the skuId column with the actual SKU and add a new column skuDisplay with the SKU display name.
In print users, we could leave the skuId column with space separated actual SKUs and add a new column  skuDisplay with comma (or some other character) separated SKU display names

In the info user Licenses section, we could show SKU: SKU display name