### PR TITLE
Clean up SKU handling

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -4351,18 +4351,14 @@ def getImap(users):
         print u'User: {0}, IMAP Enabled: {1} ({2}/{3})'.format(user, enabled, i, count)
 
 def getProductAndSKU(sku):
-  product = None
   l_sku = sku.lower().replace(u'-', u'').replace(u' ', u'')
   for a_sku, sku_values in SKUS.items():
-    if l_sku == a_sku.lower().replace(u'-', u'') or l_sku in sku_values[u'aliases']:
-      sku = a_sku
-      product = sku_values[u'product']
-      break
-  if not product:
-    try:
-      product = re.search(u'^([A-Z,a-z]*-[A-Z,a-z]*)', sku).group(1)
-    except AttributeError:
-      product = sku
+    if l_sku == a_sku.lower().replace(u'-', u'') or l_sku in sku_values[u'aliases'] or l_sku == sku_values[u'displayName'].lower().replace(u' ', u''):
+      return (sku_values[u'product'], a_sku)
+  try:
+    product = re.search(u'^([A-Z,a-z]*-[A-Z,a-z]*)', sku).group(1)
+  except AttributeError:
+    product = sku
   return (product, sku)
 
 def doLicense(users, operation):
@@ -8786,7 +8782,7 @@ def doPrintUsers():
         for u_license in licenses:
           if u_license[u'userId'].lower() == user[u'primaryEmail'].lower():
             user_licenses.append(u_license[u'skuId'])
-        user.update(Licenses=u' '.join(user_licenses))
+        user.update(Licenses=u','.join(user_licenses))
   writeCSVfile(csvRows, titles, u'Users', todrive)
 
 GROUP_ARGUMENT_TO_PROPERTY_TITLE_MAP = {


### PR DESCRIPTION
As the display name of SKUs is being written to CSV files, it has to be accepted on input

In print users, the skuIds values need to be separated by something other that space as the display names have spaces in them

I'm wondering if writing the display names to the CSV files is going to break existing users scripts. In print licenses, we could leave the skuId column with the actual SKU ID and add a new column skuDisplay with the SKU display name.
In print users, we could leave the skuId column with space separated actual SKU IDs and add a new column skuDisplay with comma (or some other character) separated SKU display names

In the info user Licenses section, we could show SKU ID (SKU display name)