### PR TITLE
Add countsonly option to gam print courses to get student/teacher counts without full profiles

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -614,11 +614,11 @@ gam calendar <CalendarItem> deleteevent (id|eventid <EventID>)* (query|eventquer
 gam calendar <CalendarItem> wipe
 
 gam update cros <CrOSItem> (<CrOSAttributes>+)|(action deprovision_same_model_replace|deprovision_different_model_replace|deprovision_retiring_device|disable|reenable [acknowledge_device_touch_requirement])
-gam info cros <CrOSItem> [nolists] [listlimit <Number>]
+gam info cros <CrOSItem> [nolists] [listlimit <Number>] [start <Date>] [end <Date>]
 	[basic|full|allfields] <CrOSFieldName>* [fields <CrOSFieldNameList>]
 
 gam print cros [todrive] [query <QueryCrOS>]
-	[orderby <CrOSOrderByFieldName> [ascending|descending]] [nolists] [listlimit <Number>]
+	[orderby <CrOSOrderByFieldName> [ascending|descending]] [nolists] [listlimit <Number>] [start <Date>] [end <Date>]
 	[basic|full|allfields] <CrOSFieldName>* [fields <CrOSFieldNameList>]
 gam <CrOSTypeEntity> print
 
@@ -632,11 +632,27 @@ Prints a header row and selected fields for specified CrOS devices.
 
 The basic argument yields these column headers: deviceId,annotatedAssetId,annotatedLocation,annotatedUser,lastSync,notes,serialNumber,status
 The full argument yields all column headers including two headers, recentUsers and activeTimeRanges,
-that repeat with two subvalues each, yielding a large number of columns that make the output hard to process.
+that repeat with two/four subvalues each, yielding a large number of columns that make the output hard to process.
 The nolists argument suppresses these two headers; if you want these headers in a more manageable form use the following arguments.
-The listlimit <Number> argument limits the number of repetitions to <Number>. If <Number> equals zero, there is no limit.
-If recentusers is specified as a field, each pair of values for recentUsers is put on a separate row with all of the other headers.
-If timeranges is specified as a field, each  pair of values for activeTimeRanges is put on a separate row with all of the other headers.
+If recentusers is specified, for each recent user, the columns recentUsers.email and recentUsers.type are output on a separate row
+with all of the other headers.
+If timeranges is specified, for each time range entry, the columns activeTimeRanges.date, activeTimeRange.activeTime,
+activeTimeRanges.duration and activeTimeRanges.minutes are output on a separate row with all of the other headers.
+The listlimit <Number> argument limits the number of repetitions to <Number>; if not specified or <Number> equals zero, there is no limit.
+The start <Date> and end <Date> arguments filter the time ranges.
+
+gam print crosactivity [todrive] [query <QueryCrOS>]
+	[recentusers] [timeranges] [both] [listlimit <Number>] [start <Date>] [end <Date>] [delimiter <String>] 
+
+The basic column headers are: deviceId,annotatedAssetId,annotatedLocation,serialNumber,orgUnitPath.
+If recentusers is specified, all of the recent users email addresses, separated by the delimiter <String>,
+with header recentUsers.email, are output with the basic headers.
+If timeranges is specified, for each time range entry, activeTimeRanges.date and activeTimeRanges.duration and activeTimeRanges.minutes,
+are output on a separate row with the basic headers.
+The default is to include both recentusers and timeranges.
+The listlimit <Number> argument limits the number of recent users and time ranges to <Number>; if not specified or <Number> equals zero, there is no limit.
+The start <Date> and end <Date> arguments filter the time ranges.
+Delimiter defaults to comma.
 
 gam update mobile <MobileItem> <MobileAttributes>+
 gam delete mobile <MobileItem>
@@ -706,7 +722,7 @@ gam update course <CourseID> <CourseAttributes>+
 gam delete course <CourseID>
 gam info course <CourseID>
 gam print courses [todrive] [teacher <UserItem>] [student <UserItem>] [alias|aliases] [delimiter <String>]
-	[show all|students|teachers] [fields <CourseFieldNameList>] [skipfields <CourseFieldNameList>]
+	[show all|students|teachers] [countsonly] [fields <CourseFieldNameList>] [skipfields <CourseFieldNameList>]
 
 gam course <CourseID> add alias <CourseAlias>
 gam course <CourseID> delete alias <CourseAlias>

--- a/src/gam.py
+++ b/src/gam.py
@@ -2150,6 +2150,13 @@ def doPrintCourses():
   if showAliases or showMembers:
     if showAliases:
       titles.append(u'Aliases')
+    if showMembers:
+      if countsOnly:
+        teachersFields = u'nextPageToken,teachers(profile(id))'
+        studentsFields = u'nextPageToken,students(profile(id))'
+      else:
+        teachersFields = u'nextPageToken,teachers(profile)'
+        studentsFields = u'nextPageToken,students(profile)'
     i = 0
     count = len(csvRows)
     for course in csvRows:
@@ -2166,13 +2173,13 @@ def doPrintCourses():
           teacher_message = u' got %%%%num_items%%%% teachers for course %s%s' % (courseId, currentCount(i, count))
           results = callGAPIpages(croom.courses().teachers(), u'list', u'teachers',
                                   page_message=teacher_message,
-                                  courseId=courseId, fields=u'nextPageToken,teachers(profile)')
+                                  courseId=courseId, fields=teachersFields)
           _saveParticipants(course, results, u'teachers')
         if showMembers != u'teachers':
           student_message = u' got %%%%num_items%%%% students for course %s%s' % (courseId, currentCount(i, count))
           results = callGAPIpages(croom.courses().students(), u'list', u'students',
                                   page_message=student_message,
-                                  courseId=courseId, fields=u'nextPageToken,students(profile)')
+                                  courseId=courseId, fields=studentsFields)
           _saveParticipants(course, results, u'students')
   sortCSVTitles([u'id', u'name'], titles)
   writeCSVfile(csvRows, titles, u'Courses', todrive)

--- a/src/gam.py
+++ b/src/gam.py
@@ -2064,6 +2064,8 @@ def doPrintCourses():
     jcount = len(participants)
     course[role] = jcount
     addTitlesToCSVfile([role], titles)
+    if countsOnly:
+      return
     j = 0
     for member in participants:
       memberTitles = []
@@ -2096,6 +2098,7 @@ def doPrintCourses():
   teacherId = None
   studentId = None
   showAliases = False
+  countsOnly = False
   delimiter = u' '
   showMembers = u''
   i = 3
@@ -2112,6 +2115,9 @@ def doPrintCourses():
       i += 1
     elif myarg in [u'alias', u'aliases']:
       showAliases = True
+      i += 1
+    elif myarg == u'countsonly':
+      countsOnly = True
       i += 1
     elif myarg == u'delimiter':
       delimiter = sys.argv[i+1]


### PR DESCRIPTION
gam print courses show all|students|teachers countsonly
This gives just the columns students/teachers but not the profiles.
This option has no effect unless show all|student|teachers is specified.