### PR TITLE
Use update instead of patch for update user

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -7048,7 +7048,7 @@ def doUpdateUser(users, i):
       body[u'emails'] = [{u'type': u'custom', u'customType': u'former_employee', u'primary': False, u'address': user_primary}]
     sys.stdout.write(u'updating user %s...\n' % user)
     if body:
-      callGAPI(cd.users(), u'patch', userKey=user, body=body)
+      callGAPI(cd.users(), u'update', userKey=user, body=body)
     if admin_body:
       callGAPI(cd.users(), u'makeAdmin', userKey=user, body=admin_body)
 


### PR DESCRIPTION
This is required in order for update user phones/organizations/addresses/... clear to work
With patch, the API ignores the empty attribute dictionary
With update, the API clears the attribute