### PR TITLE
gotTopLevelOrg must take orgUnitPath as parameter

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -8510,11 +8510,11 @@ def orgUnitPathQuery(path):
     return u"orgUnitPath='{0}'".format(path.replace(u"'", u"\'"))
   return None
 
-def getTopLevelOrgId(cd):
+def getTopLevelOrgId(cd, orgUnitPath):
   try:
     # create a temp org so we can learn what the top level org ID is (sigh)
     temp_org = callGAPI(cd.orgunits(), u'insert', customerId=GC_Values[GC_CUSTOMER_ID],
-                        body={u'name': u'temp-delete-me', u'parentOrgUnitPath': u'/'},
+                        body={u'name': u'temp-delete-me', u'parentOrgUnitPath': orgUnitPath},
                         fields=u'parentOrgUnitId,orgUnitId')
     callGAPI(cd.orgunits(), u'delete', customerId=GC_Values[GC_CUSTOMER_ID], orgUnitPath=temp_org[u'orgUnitId'])
     return temp_org[u'parentOrgUnitId']
@@ -8546,7 +8546,7 @@ def doGetOrgInfo(name=None, return_attrib=None):
     if u'organizationUnits' in orgs and orgs[u'organizationUnits']:
       name = orgs[u'organizationUnits'][0][u'parentOrgUnitId']
     else:
-      topLevelOrgId = getTopLevelOrgId(cd)
+      topLevelOrgId = getTopLevelOrgId(cd, u'/')
       if topLevelOrgId:
         name = topLevelOrgId
   if len(name) > 1 and name[0] == u'/':
@@ -9487,7 +9487,7 @@ def doPrintOrgs():
   orgs = callGAPI(cd.orgunits(), u'list',
                   customerId=GC_Values[GC_CUSTOMER_ID], type=listType, orgUnitPath=orgUnitPath, fields=list_fields)
   if not u'organizationUnits' in orgs:
-    topLevelOrgId = getTopLevelOrgId(cd)
+    topLevelOrgId = getTopLevelOrgId(cd, orgUnitPath)
     if topLevelOrgId:
       parentOrgIds.append(topLevelOrgId)
     orgunits = []


### PR DESCRIPTION
THis is required in doPrintOrgs when fromparent is used.