### PR TITLE
Upgrade gam update group to use API batch processing

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -705,13 +705,13 @@ gam print mobile [todrive] [query <QueryMobile>] [basic|full] [orderby <MobileOr
 
 gam create group <EmailAddress> <GroupAttributes>*
 gam update group <GroupItem> [admincreated <Boolean>] [email <EmailAddress>] <GroupAttributes>*
-gam update group <GroupItem> add [member|manager|owner] [notsuspended] <UserTypeEntity>
-gam update group <GroupItem> delete|remove [member|manager|owner] <UserTypeEntity>
-gam update group <GroupItem> sync [member|manager|owner] [notsuspended] <UserTypeEntity>
-gam update group <GroupItem> update [member|manager|owner] <UserTypeEntity>
+gam update group <GroupItem> add [owner|manager|member] [notsuspended] <UserTypeEntity>
+gam update group <GroupItem> delete|remove [owner|manager|member] <UserTypeEntity>
+gam update group <GroupItem> sync [owner|manager|member] [notsuspended] <UserTypeEntity>
+gam update group <GroupItem> update [owner|manager|member] <UserTypeEntity>
+gam update group <GroupItem> clear [member] [manager] [owner] [suspended]
 gam delete group <GroupItem>
 gam info group <GroupItem> [nousers] [noaliases] [groups]
-gam update group <GroupItem> clear [member] [manager] [owner]
 
 gam print groups [todrive] ([domain <DomainName>] [member <UserItem>])
 	[maxresults <Number>] [allfields|([settings] <GroupFieldName>* [fields <GroupFieldNameList>])] [delimiter <String>]

--- a/src/gam.py
+++ b/src/gam.py
@@ -9715,9 +9715,9 @@ def doPrintMobileDevices():
       if attrib in [u'name', u'email', u'otherAccountsInfo']:
         if attrib not in titles:
           titles.append(attrib)
-        if listLimit:
+        if listLimit > 0:
           row[attrib] = delimiter.join(mobile[attrib][0:listLimit])
-        else:
+        elif listLimit == 0:
           row[attrib] = delimiter.join(mobile[attrib])
       elif attrib == u'applications':
         if appsLimit >= 0:

--- a/src/var.py
+++ b/src/var.py
@@ -568,6 +568,8 @@ GC_DOMAIN = u'domain'
 GC_DRIVE_DIR = u'drive_dir'
 # When retrieving lists of Drive files/folders from API, how many should be retrieved in each chunk
 GC_DRIVE_MAX_RESULTS = u'drive_max_results'
+# When retrieving lists of Google Group members from API, how many should be retrieved in each chunk
+GC_MEMBER_MAX_RESULTS = u'member_max_results'
 # If no_browser is False, writeCSVfile won't open a browser when todrive is set
 # and doRequestOAuth prints a link and waits for the verification code when oauth2.txt is being created
 GC_NO_BROWSER = u'no_browser'
@@ -609,6 +611,7 @@ GC_Defaults = {
   GC_DOMAIN: u'',
   GC_DRIVE_DIR: u'',
   GC_DRIVE_MAX_RESULTS: 1000,
+  GC_MEMBER_MAX_RESULTS: 200,
   GC_NO_BROWSER: False,
   GC_NO_CACHE: False,
   GC_NO_UPDATE_CHECK: False,
@@ -652,6 +655,7 @@ GC_VAR_INFO = {
   GC_DOMAIN: {GC_VAR_TYPE: GC_TYPE_STRING},
   GC_DRIVE_DIR: {GC_VAR_TYPE: GC_TYPE_DIRECTORY},
   GC_DRIVE_MAX_RESULTS: {GC_VAR_TYPE: GC_TYPE_INTEGER, GC_VAR_LIMITS: (1, 1000)},
+  GC_MEMBER_MAX_RESULTS: {GC_VAR_TYPE: GC_TYPE_INTEGER, GC_VAR_LIMITS: (1, 10000)},
   GC_NO_BROWSER: {GC_VAR_TYPE: GC_TYPE_BOOLEAN},
   GC_NO_CACHE: {GC_VAR_TYPE: GC_TYPE_BOOLEAN},
   GC_NO_UPDATE_CHECK: {GC_VAR_TYPE: GC_TYPE_BOOLEAN},
@@ -713,18 +717,37 @@ OAUTH2_TOKEN_ERRORS = [
   ]
 #
 # callGAPI throw reasons
+GAPI_ABORTED = u'aborted'
+GAPI_AUTH_ERROR = u'authError'
 GAPI_BACKEND_ERROR = u'backendError'
 GAPI_BAD_REQUEST = u'badRequest'
+GAPI_CONDITION_NOT_MET = u'conditionNotMet'
+GAPI_CYCLIC_MEMBERSHIPS_NOT_ALLOWED = u'cyclicMembershipsNotAllowed'
+GAPI_DOMAIN_CANNOT_USE_APIS = u'domainCannotUseApis'
+GAPI_DOMAIN_NOT_FOUND = u'domainNotFound'
+GAPI_DUPLICATE = u'duplicate'
+GAPI_FAILED_PRECONDITION = u'failedPrecondition'
 GAPI_FORBIDDEN = u'forbidden'
+GAPI_GROUP_NOT_FOUND = u'groupNotFound'
 GAPI_INTERNAL_ERROR = u'internalError'
 GAPI_INVALID = u'invalid'
+GAPI_INVALID_ARGUMENT = u'invalidArgument'
+GAPI_INVALID_MEMBER = u'invalidMember'
+GAPI_MEMBER_NOT_FOUND = u'memberNotFound'
 GAPI_NOT_FOUND = u'notFound'
+GAPI_NOT_IMPLEMENTED = u'notImplemented'
 GAPI_QUOTA_EXCEEDED = u'quotaExceeded'
 GAPI_RATE_LIMIT_EXCEEDED = u'rateLimitExceeded'
+GAPI_RESOURCE_NOT_FOUND = u'resourceNotFound'
 GAPI_SERVICE_NOT_AVAILABLE = u'serviceNotAvailable'
+GAPI_SYSTEM_ERROR = u'systemError'
 GAPI_USER_NOT_FOUND = u'userNotFound'
 GAPI_USER_RATE_LIMIT_EXCEEDED = u'userRateLimitExceeded'
 #
 GAPI_DEFAULT_RETRY_REASONS = [GAPI_QUOTA_EXCEEDED, GAPI_RATE_LIMIT_EXCEEDED, GAPI_USER_RATE_LIMIT_EXCEEDED, GAPI_BACKEND_ERROR, GAPI_INTERNAL_ERROR]
 GAPI_GMAIL_THROW_REASONS = [GAPI_SERVICE_NOT_AVAILABLE]
 GAPI_GPLUS_THROW_REASONS = [GAPI_SERVICE_NOT_AVAILABLE]
+GAPI_GROUP_GET_THROW_REASONS = [GAPI_GROUP_NOT_FOUND, GAPI_DOMAIN_NOT_FOUND, GAPI_DOMAIN_CANNOT_USE_APIS, GAPI_FORBIDDEN, GAPI_BAD_REQUEST]
+GAPI_GROUP_GET_RETRY_REASONS = [GAPI_INVALID, GAPI_SYSTEM_ERROR]
+GAPI_MEMBERS_THROW_REASONS = [GAPI_GROUP_NOT_FOUND, GAPI_DOMAIN_NOT_FOUND, GAPI_DOMAIN_CANNOT_USE_APIS, GAPI_INVALID, GAPI_FORBIDDEN]
+GAPI_MEMBERS_RETRY_REASONS = [GAPI_SYSTEM_ERROR]


### PR DESCRIPTION
This allows gam update group sync commands to be used in gam batch and gam csv commands.

Add/delete/update and clear will be faster due to batching.

GAPI exception handling improved to support additional error checking.

Allow listlimit -1 in print mobile devices
appslimit = -1 and listlimit -1: show no repeating elements
appslimit = 0 and listlimit 0: show all repeating elements
appslimit = N and listlimit N: show N repeating elements