### PR TITLE
Minor locations/sshPublicKeys cleanup

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -380,13 +380,16 @@ Named items
 	is2svenforced|
 	is2svenrolled|
 	lastlogintime|
+	locations|location|
 	noneditablealiases|aliases|nicknames|
 	notes|note|
 	organizations|organization|
 	orgunitpath|org|ou|
 	phones|phone|
+	posixaccounts|posix|
 	primaryemail|username|
 	relations|relation|
+	ssh|sshkeys|sshpublickeys|
 	suspended|
 	thumbnailphotourl|photo|photourl|
 	websites|website|
@@ -556,6 +559,7 @@ Item attributes
 	(im|ims clear|(type work|home|other|(custom <String>) protocol aim|gtalk|icq|jabber|msn|net_meeting|qq|skype|yahoo|(custom_protocol <String>) <String> [notprimary|primary]))|
 	(ipwhitelisted <Boolean>)|
 	(lastname|familyname <String>)|
+	(location|locations clear|(type default|desk|<String> area <String> [building|buildingid <String>] [floor|floorname <String>] [section|floorsection <String>] [desk|deskcode <String>] endlocation))|
 	(note|notes clear|([text_plain|text_html] <String>|(file <FileName> [charset <Charset>])))|
 	(organization|organizations clear|([type domain_only|school|unknown|work] [customtype <String>] [name <String>] [title <String>] [department <String>] [symbol <String>]
 		[costcenter <String>]  [location <String>] [description <String>] [domain <String>] notprimary|primary))|
@@ -563,7 +567,9 @@ Item attributes
 	(password random|<String>)|
 	(phone|phones clear|([type work|home|other|work_fax|home_fax|other_fax|main|company_main|assistant|mobile|work_mobile|pager|work_pager|car|radio|callback|isdn|telex|tty_tdd|grand_central|(custom <String>)]
 		[value <String>] notprimary|primary))|
+	(posix|posixaccounts clear|(username <String> uid <Integer> gid <Integer> [system|systemid <String>] [home|homedirectory <String>] [shell <String>] [gecos <String>] [primary <Boolean>] endposix))|
 	(relation|relations clear|(spouse|child|mother|father|parent|brother|sister|friend|relative|domestic_partner|manager|assistant|referred_by|partner|<String> <String>))|
+	(ssh|sshkeys|sshpublickeys clear|(key <String> [expires <Integer>] endssh))|
 	(suspended <Boolean>)|
 	(website|websites clear|(home_page|blog|profile|work|home|other|ftp|reservations|app_install_page|<String> <URL> [notprimary|primary]))|
 	(<SchemaName>.<FieldName> [multivalued|multivalue|value|multinonempty [type work|home|other|(custom <String>)]] <String>)

--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -544,7 +544,7 @@ Item attributes
 	field <FieldName> (type bool|date|double|email|int64|phone|string) [multivalued|multivalue] [indexed] [restricted] [range <Number> <Number>] endfield
 
 <UserAttributes> ::=
-	(address|addresses clear|(type work|home|other|(custom <String>) [unstructured|formatted <String>] [pobox <String>] [extendedaddress <String>] [streetaddress <String>]
+	(address clear|(type work|home|other|(custom <String>) [unstructured|formatted <String>] [pobox <String>] [extendedaddress <String>] [streetaddress <String>]
 		[locality <String>] [region <String>] [postalcode <String>] [country <String>] [countrycode <String>] notprimary|primary))|
 	(admin <Boolean>)|
 	(agreed2terms|agreedtoterms <Boolean>)|
@@ -552,26 +552,26 @@ Item attributes
 	(crypt|sha|sha1|sha-1|md5|nohash)|
 	(customerid <String>)|
 	(email|primaryemail|username <EmailAddress>)|
-	(emails|otheremail|otheremails clear|(work|home|other|<String> <String>))|
-	(externalid|externalids clear|(account|customer|network|organization|<String> <String>))|
+	(otheremail clear|(work|home|other|<String> <String>))|
+	(externalid clear|(account|customer|network|organization|<String> <String>))|
 	(firstname|givenname <String>)|
 	(gal|includeinglobaladdresslist <Boolean>)|
-	(im|ims clear|(type work|home|other|(custom <String>) protocol aim|gtalk|icq|jabber|msn|net_meeting|qq|skype|yahoo|(custom_protocol <String>) <String> [notprimary|primary]))|
+	(im clear|(type work|home|other|(custom <String>) protocol aim|gtalk|icq|jabber|msn|net_meeting|qq|skype|yahoo|(custom_protocol <String>) <String> [notprimary|primary]))|
 	(ipwhitelisted <Boolean>)|
 	(lastname|familyname <String>)|
-	(location|locations clear|(type default|desk|<String> area <String> [building|buildingid <String>] [floor|floorname <String>] [section|floorsection <String>] [desk|deskcode <String>] endlocation))|
-	(note|notes clear|([text_plain|text_html] <String>|(file <FileName> [charset <Charset>])))|
-	(organization|organizations clear|([type domain_only|school|unknown|work] [customtype <String>] [name <String>] [title <String>] [department <String>] [symbol <String>]
+	(location clear|(type default|desk|<String> area <String> [building|buildingid <String>] [floor|floorname <String>] [section|floorsection <String>] [desk|deskcode <String>] endlocation))|
+	(note clear|([text_plain|text_html] <String>|(file <FileName> [charset <Charset>])))|
+	(organization clear|([type domain_only|school|unknown|work] [customtype <String>] [name <String>] [title <String>] [department <String>] [symbol <String>]
 		[costcenter <String>]  [location <String>] [description <String>] [domain <String>] notprimary|primary))|
 	(org|ou|orgunitpath <OrgUnitPath>)
 	(password random|<String>)|
-	(phone|phones clear|([type work|home|other|work_fax|home_fax|other_fax|main|company_main|assistant|mobile|work_mobile|pager|work_pager|car|radio|callback|isdn|telex|tty_tdd|grand_central|(custom <String>)]
+	(phone clear|([type work|home|other|work_fax|home_fax|other_fax|main|company_main|assistant|mobile|work_mobile|pager|work_pager|car|radio|callback|isdn|telex|tty_tdd|grand_central|(custom <String>)]
 		[value <String>] notprimary|primary))|
-	(posix|posixaccounts clear|(username <String> uid <Integer> gid <Integer> [system|systemid <String>] [home|homedirectory <String>] [shell <String>] [gecos <String>] [primary <Boolean>] endposix))|
-	(relation|relations clear|(spouse|child|mother|father|parent|brother|sister|friend|relative|domestic_partner|manager|assistant|referred_by|partner|<String> <String>))|
-	(ssh|sshkeys|sshpublickeys clear|(key <String> [expires <Integer>] endssh))|
+	(posix clear|(username <String> uid <Integer> gid <Integer> [system|systemid <String>] [home|homedirectory <String>] [shell <String>] [gecos <String>] [primary <Boolean>] endposix))|
+	(relation clear|(spouse|child|mother|father|parent|brother|sister|friend|relative|domestic_partner|manager|assistant|referred_by|partner|<String> <String>))|
+	(sshkeys clear|(key <String> [expires <Integer>] endssh))|
 	(suspended <Boolean>)|
-	(website|websites clear|(home_page|blog|profile|work|home|other|ftp|reservations|app_install_page|<String> <URL> [notprimary|primary]))|
+	(website clear|(home_page|blog|profile|work|home|other|ftp|reservations|app_install_page|<String> <URL> [notprimary|primary]))|
 	(<SchemaName>.<FieldName> [multivalued|multivalue|value|multinonempty [type work|home|other|(custom <String>)]] <String>)
 
 gam version [check] [simple]

--- a/src/gam.py
+++ b/src/gam.py
@@ -6785,7 +6785,7 @@ def getUserAttributes(i, cd, updateCmd=False):
         note[u'value'] = sys.argv[i].replace(u'\\n', u'\n')
         i += 1
       body[u'notes'] = note
-    elif myarg == u'location':
+    elif myarg in [u'location', u'locations']:
       i += 1
       if checkClearBodyList(i, body, u'locations'):
         i += 1
@@ -6821,7 +6821,7 @@ def getUserAttributes(i, cd, updateCmd=False):
           print u'ERROR: %s is not a valid argument for user location details. Make sure user location details end with an endlocation argument'
           sys.exit(3)
       appendItemToBodyList(body, u'locations', location)
-    elif myarg in [u'ssh', u'sshpublickeys', u'sshkeys']:
+    elif myarg in [u'ssh', u'sshkeys', u'sshpublickeys']:
       i += 1
       if checkClearBodyList(i, body, u'sshPublicKeys'):
         i += 1
@@ -6842,7 +6842,7 @@ def getUserAttributes(i, cd, updateCmd=False):
           print u'ERROR: %s is not a valid argument for user ssh details. Make sure user ssh details end with an endssh argument'
           sys.exit(3)
       appendItemToBodyList(body, u'sshPublicKeys', ssh)
-    elif myarg in [u'posix', u'posixaccount']:
+    elif myarg in [u'posix', u'posixaccounts']:
       i += 1
       if checkClearBodyList(i, body, u'posixAccounts'):
         i += 1
@@ -8632,7 +8632,7 @@ def doGetUserInfo(user_email=None):
         print utils.convertUTF8(u' %s: %s' % (key, location[key]))
       print u''
   if u'sshPublicKeys' in user:
-    print u'Public SSH Keys:'
+    print u'SSH Public Keys:'
     for sshkey in user[u'sshPublicKeys']:
       for key in sshkey:
         print utils.convertUTF8(u' %s: %s' % (key, sshkey[key]))
@@ -9742,7 +9742,7 @@ USER_ARGUMENT_TO_PROPERTY_MAP = {
   u'relations': [u'relations',],
   u'ssh': [u'sshPublicKeys',],
   u'sshkeys': [u'sshPublicKeys',],
-  u'publicsshkeys': [u'sshPublicKeys',],
+  u'sshpublickeys': [u'sshPublicKeys',],
   u'suspended': [u'suspended', u'suspensionReason',],
   u'thumbnailphotourl': [u'thumbnailPhotoUrl',],
   u'username': [u'primaryEmail',],


### PR DESCRIPTION
Make options names internally consistent and consistent with other commands.

Drop publicsshkeys, too may choices

Change title to SSH Public Keys to match Google's title