### PR TITLE
Update user attribute handling

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -6435,12 +6435,15 @@ def doGetUserSchema():
 
 def getUserAttributes(i, cd, updateCmd=False):
   def getEntryType(i, entry, entryTypes, setTypeCustom=True):
-# Allow a|b|c|<String>, a|b|c|custom <String>
-# For all fields except organizations, when setting a custom type you do:
-# entry[u'type'] = u'custom'
-# entry[u'customType'] = <String>
-# For organizations, you don't set entry[u'type'] = u'custom'
-# Preserve case of custom types
+    """ Get attribute entry type
+    entryTypes is list of pre-defined types, a|b|c
+    Allow a|b|c|<String>, a|b|c|custom <String>
+    setTypeCustom=True, For all fields except organizations, when setting a custom type you do:
+    entry[u'type'] = u'custom'
+    entry[u'customType'] = <String>
+    setTypeCustom=False, For organizations, you don't set entry[u'type'] = u'custom'
+    Preserve case of custom types
+    """
     utype = sys.argv[i]
     ltype = utype.lower()
     if ltype == u'custom':
@@ -6449,10 +6452,13 @@ def getUserAttributes(i, cd, updateCmd=False):
       ltype = utype.lower()
     if ltype in entryTypes:
       entry[u'type'] = ltype
+      entry.pop(u'customType', None)
     else:
       entry[u'customType'] = utype
       if setTypeCustom:
         entry[u'type'] = u'custom'
+      else:
+        entry.pop(u'type', None)
     return i+1
 
   def checkClearBodyList(i, body, itemName):

--- a/src/gam.py
+++ b/src/gam.py
@@ -6709,6 +6709,7 @@ def getUserAttributes(i, cd, updateCmd=False):
           i += 2
         elif myopt == u'customtype':
           organization[u'customType'] = sys.argv[i+1]
+          organization.pop(u'type', None)
           i += 2
         elif myopt == u'type':
           i = getEntryType(i+1, organization, USER_ORGANIZATION_TYPES, setTypeCustom=False)


### PR DESCRIPTION
User attribite type handling issues.

Custom types have their case lowered.

Use custom keyword as part of type
Old - address, im, phone: `type a|b|c|(custom <String>`)
New - address, im, phone: type `a|b|c|<String>`

Dropping custom keyword will break existing scripts

Use separate keyword for custom type
Old - organization: `(type a|b|c) | (customtype <String>)`
New - organization: `(type a|b|c|<String>)`

Dropping customtype keyword will break existing scripts

Unlike all other attributes, you do not set `type: custom` when customType is set

Use implied custom
Old - location: `type a|b|c|<String>`
New - location: `type a|b|c|<String>`

No change

Use implied custom, no type keyword
Old - externalid, otheremail, relation, website: `a|b|c|<String>`
New - externalid, otheremail, relation, website: `a|b|c|<String>`

No change

This update normalizes the type handling.

Case of custom types is preserved.

In update, for all fields, you can do:
`a|b|c|<String>`
`a|b|c|custom <String>`

`customtype <String>` is still allowed for organization for backward compatibility.