### PR TITLE
Clean up printer register

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -824,7 +824,6 @@ gam show guardian|guardians [invitedguardian <EmailAddress>] [student <StudentIt
 gam print guardian|guardians [todrive] [invitedguardian <EmailAddress>] [student <StudentItem>] [invitations [states <GuardianStateList>]] [<UserTypeEntity>]
 gam cancel guardianinvitation|guardianinvitations <GuardianInvitationID> <StudentItem>
 
-gam printer register
 gam update printer <PrinterID> <PrinterAttributes>+
 gam delete printer <PrinterID>
 gam info printer <PrinterID> [everything]

--- a/src/gam.py
+++ b/src/gam.py
@@ -11957,6 +11957,9 @@ def ProcessGAMCommand(args):
         sys.exit(2)
       sys.exit(0)
     elif command == u'printer':
+      if sys.argv[2].lower() == u'register':
+        doPrinterRegister()
+        sys.exit(0)
       argument = sys.argv[3].lower()
       if argument == u'showacl':
         doPrinterShowACL()
@@ -11964,8 +11967,6 @@ def ProcessGAMCommand(args):
         doPrinterAddACL()
       elif argument in [u'del', u'delete', u'remove']:
         doPrinterDelACL()
-      elif argument == u'register':
-        doPrinterRegister()
       else:
         print u'ERROR: %s is not a valid argument for "gam printer..."' % argument
         sys.exit(2)


### PR DESCRIPTION
Remove printer register from documentation
Make non-documented command be:
    `gam printer register`
instead of:
    `gam printer xxx register`
as xxx isn't used (it's PrinterID for other commands)