### PR TITLE
python2 as env

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # GAM


### PR DESCRIPTION
In march 2018 homebrew will point change `python` to python 3:
https://brew.sh/2018/01/19/homebrew-1.5.0/