### PR TITLE
Stop patching google_auth_httplib2 in favor of wrapping Request.__call__ from gam.py

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -95,7 +95,7 @@ def _request_with_user_agent(self, *args, **kwargs):
     else:
       kwargs['headers']['user-agent'] = GAM_USER_AGENT
   else:
-    kwargs.headers = {'user-agent': GAM_USER_AGENT}
+    kwargs['headers'] = {'user-agent': GAM_USER_AGENT}
   return google_auth_httplib2_request_call(self, *args, **kwargs)
 
 google_auth_httplib2.Request.__call__ = _request_with_user_agent


### PR DESCRIPTION
Maintaining a patch in an external library can be burdensome over time. Instead of using a local patch in google_auth_httplib2.py, this change reverts to the upstream HEAD and moves the patched functionality into gam.py.

Calls to google_auth_httplib2.Request.__call__ are wrapped to include the user agent in the headers kwarg. Note that this has the side effect of putting the GAM user agent string into every request passing through google_auth_httplib2 in GAM.