### PR TITLE
Four fixes

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -189,7 +189,7 @@ If an item contains spaces, it should be surrounded by ".
 <QueryDriveFile> ::= <String> See: https://developers.google.com/drive/v2/web/search-parameters
 <QueryGmail> ::= <String> See: https://support.google.com/mail/answer/7190
 <QueryGroup> ::= <String> See: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
-<QueryMobile> ::= <String> See: https://support.google.com/a/answer/1408863?hl=en#search
+<QueryMobile> ::= <String> See: https://support.google.com/a/answer/7549103
 <QueryPrinter> ::= <String> See: https://developers.google.com/cloud-print/docs/appInterfaces#search
 <QueryPrintJob> ::= <String> See: https://developers.google.com/cloud-print/docs/appInterfaces#parameters_3
 <QueryUser> ::= <String> See: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
@@ -838,7 +838,7 @@ gam update customer <CustomerAttributes>*
 
 gam info customer
 
-<DataTransferService> ::= googledrive|gdrive|drive|"drive and docs"|calendar
+<DataTransferService> ::= googledrive|gdrive|drive|"drive and docs"|calendar|gplus|google+|googleplus
 
 gam create datatransfer|transfer <OldOwnerID> <DataTransferService> <NewOwnerID> (<ParameterKey> <ParameterValue>)*
 gam info datatransfer|transfer <TransferID>
@@ -1009,7 +1009,7 @@ gam create verify|verification <DomainName>
 gam update verify|verification <DomainName> cname|txt|text|site|file
 gam info verify|verification
 
-gam create course id|alias <CourseAlias> <CourseAttributes>*
+gam create course [id|alias <CourseAlias>] <CourseAttributes>*
 gam update course <CourseID> <CourseAttributes>+
 gam delete course <CourseID>
 gam info course <CourseID>

--- a/src/gam-install.sh
+++ b/src/gam-install.sh
@@ -135,9 +135,11 @@ if type(release) is list:
     break
 try:
   for asset in release['assets']:
-    if asset[sys.argv[1]].endswith('$gamfile'):
-      print(asset[sys.argv[1]])
+    if asset[attrib].endswith('$gamfile'):
+      print(asset[attrib])
       break
+  else:
+    print('ERROR: Attribute: {0} for $gamfile version {1} not found'.format(attrib, gamversion))
 except KeyError:
   print('ERROR: assets value not found in JSON value of:\n\n%s' % release)"
 
@@ -155,7 +157,15 @@ if (( $rc != 0 )); then
 fi
 
 browser_download_url=$(echo "$release_json" | $pycmd -c "$pycode" browser_download_url $gamversion)
+if [[ ${browser_download_url:0:5} = "ERROR" ]]; then
+  echo_red "${browser_download_url}"
+  exit
+fi
 name=$(echo "$release_json" | $pycmd -c "$pycode" name $gamversion)
+if [[ ${name:0:5} = "ERROR" ]]; then
+  echo_red "${name}"
+  exit
+fi
 # Temp dir for archive
 #temp_archive_dir=$(mktemp -d)
 temp_archive_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')

--- a/src/gam.py
+++ b/src/gam.py
@@ -11679,7 +11679,7 @@ def getUsersToModify(entity_type=None, entity=None, silent=False, member_type=No
                             query=query, maxResults=GC_Values[GC_USER_MAX_RESULTS])
     ou = ou.lower()
     for member in members:
-      if (ou == member[u'orgUnitPath'].lower()) and not (checkNotSuspended and member[u'suspended']):
+      if (ou == member.get(u'orgUnitPath', u'').lower()) and not (checkNotSuspended and member[u'suspended']):
         users.append(member[u'primaryEmail'])
     if not silent:
       sys.stderr.write(u"%s Users are directly in the OU.\n" % len(users))
@@ -12824,7 +12824,7 @@ def ProcessGAMCommand(args):
         deleteDelegate(users)
       elif delWhat == u'calendar':
         deleteCalendar(users)
-      elif delWhat == u'label':
+      elif delWhat  in [u'labels', u'label']:
         doDeleteLabel(users)
       elif delWhat in [u'message', u'messages']:
         runCmdForUsers(doProcessMessagesOrThreads, users, default_to_batch=True, function=u'delete', unit=u'messages')

--- a/src/var.py
+++ b/src/var.py
@@ -156,6 +156,9 @@ SERVICE_NAME_CHOICES_MAP = {
   u'googledrive': u'Drive and Docs',
   u'gdrive': u'Drive and Docs',
   u'calendar': u'Calendar',
+  u'gplus': u'Google+',
+  u'google+': u'Google+',
+  u'googleplus': u'Google+',
   }
 
 PRINTJOB_ASCENDINGORDER_MAP = {


### PR DESCRIPTION
1) Handle errors in gam-install.sh if user asks for unknown version
2) Over the last few days users get created but their org unit doesn't get assigned. If you say `gam ou /Path/To/Ou print users` you get a trap because you get a user with a primaryEmail and no orgUnitPath.
3) Make delete label take labels like all other label commands
4) Add data transfer service Google+ abbreviations like drive; this avoids an API call