### PR TITLE
Import move cleanup

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -27,7 +27,6 @@ import os
 import string
 import time
 import base64
-import calendar
 import codecs
 import ConfigParser
 import csv
@@ -603,7 +602,7 @@ def doGAMCheckForUpdates(forceCheck=False):
       systemErrorExit(4, u'GAM Latest Version information not available')
 
   current_version = gam_version
-  now_time = calendar.timegm(time.gmtime())
+  now_time = int(time.time())
   if forceCheck:
     check_url = GAM_ALL_RELEASES # includes pre-releases
   else:
@@ -9834,32 +9833,26 @@ def doSiteVerifyAttempt():
     print u'Method:  %s' % verify_data[u'method']
     print u'Token:      %s' % verify_data[u'token']
     if verify_data[u'method'] == u'DNS_CNAME':
+      resolver = dns.resolver.Resolver()
+      resolver.nameservers = [u'8.8.8.8', u'8.8.4.4']
+      cname_token = verify_data[u'token']
+      cname_list = cname_token.split(u' ')
+      cname_subdomain = cname_list[0]
       try:
-        resolver = dns.resolver.Resolver()
-        resolver.nameservers = [u'8.8.8.8', u'8.8.4.4']
-        cname_token = verify_data[u'token']
-        cname_list = cname_token.split(u' ')
-        cname_subdomain = cname_list[0]
-        try:
-          answers = resolver.query(u'%s.%s' % (cname_subdomain, a_domain), u'A')
-          for answer in answers:
-            print u'DNS Record: %s' % answer
-        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-          print u'ERROR: No such domain found in DNS!'
-      except ImportError:
-        pass
+        answers = resolver.query(u'%s.%s' % (cname_subdomain, a_domain), u'A')
+        for answer in answers:
+          print u'DNS Record: %s' % answer
+      except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+        print u'ERROR: No such domain found in DNS!'
     elif verify_data[u'method'] == u'DNS_TXT':
+      resolver = dns.resolver.Resolver()
+      resolver.nameservers = [u'8.8.8.8', u'8.8.4.4']
       try:
-        resolver = dns.resolver.Resolver()
-        resolver.nameservers = [u'8.8.8.8', u'8.8.4.4']
-        try:
-          answers = resolver.query(a_domain, u'TXT')
-          for answer in answers:
-            print u'DNS Record: %s' % str(answer).replace(u'"', u'')
-        except dns.resolver.NXDOMAIN:
-          print u'ERROR: no such domain found in DNS!'
-      except ImportError:
-        pass
+        answers = resolver.query(a_domain, u'TXT')
+        for answer in answers:
+          print u'DNS Record: %s' % str(answer).replace(u'"', u'')
+      except dns.resolver.NXDOMAIN:
+        print u'ERROR: no such domain found in DNS!'
     return
   print u'SUCCESS!'
   print u'Verified:  %s' % verify_result[u'site'][u'identifier']


### PR DESCRIPTION
calendar.timegm(time.gmtime()) and int(time.time()) return the same value. import calendar can be dropped as it caused a name conflict later on.

With import dns.resolver moved to the top, try except ImportError can be dropped.