### PR TITLE
Translate cp65001 encoding to UTF-8

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -94,6 +94,12 @@ Go to the following link in your browser:
     {address}
 """
 
+def cp65001(name):
+  if name.lower() == "cp65001":
+    return codecs.lookup("utf-8")
+
+codecs.register(cp65001)
+
 # Override and wrap google_auth_httplib2 request methods so that the GAM
 # user-agent string is inserted into HTTP request headers.
 def _request_with_user_agent(request_method):
@@ -10907,7 +10913,7 @@ def doPrintShowAlerts():
         titles.append(field)
     csv_rows.append(aj)
   writeCSVfile(csv_rows, titles, u'Alerts', False)
- 
+
 def doPrintShowAlertFeedback():
   _, ac = buildAlertCenterGAPIObject(_getValueFromOAuth(u'email'))
   feedback = callGAPIpages(ac.alerts().feedback(), u'list', u'feedback', alertId=u'-')


### PR DESCRIPTION
It seems that python 2 `codec` library does not support the Windows encoding 65001 in both `cmd` and `powershell` and [was only added in python 3](https://docs.python.org/dev/whatsnew/3.3.html#codecs):

```
Traceback (most recent call last):
  File "gam.py", line 13306, in <module>
  File "gam.py", line 12831, in ProcessGAMCommand
  File "gam.py", line 2527, in doPrintCourses
  File "gam.py", line 163, in printGettingAllItems
LookupError: unknown encoding: cp65001
[20780] Failed to execute script gam
```

It's sort of a hack [as described in this StackOverflow's thread](https://stackoverflow.com/questions/14345066/converting-unicode-characters-from-returned-json-in-python), but you can enforce the `cp65001` encoding to use utf-8.