### PR TITLE
Fix bug in setting scopes

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -13126,6 +13126,7 @@ Append an 'r' to grant read-only access or an 'a' to grant action-only access.
       if selected is None:
         # Toggle the option on/off
         option.is_selected = not option.is_selected
+        option._restriction = None
       else:
         option.is_selected = selected
     else:

--- a/src/gam.py
+++ b/src/gam.py
@@ -13126,7 +13126,7 @@ Append an 'r' to grant read-only access or an 'a' to grant action-only access.
       if selected is None:
         # Toggle the option on/off
         option.is_selected = not option.is_selected
-        option._restriction = None
+        option.unrestrict()
       else:
         option.is_selected = selected
     else:


### PR DESCRIPTION
If you set an item to read only, you can't get back to not read only
```
21 *->blank
21 blank->*
21r *-> R
21 R->blank
21 blank -> R Should be *
```