### PR TITLE
Allow adding customer Id to group

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -8873,7 +8873,7 @@ def doUpdateGroup():
           item.append(user_email)
           items.append(item)
       else:
-        body = {u'role': role, u'email': users_email[0]}
+        body = {u'role': role, u'email' if users_email[0].find(u'@') != -1 else u'id': users_email[0]}
         add_text = [u'as %s' % role]
         if delivery:
           body[u'delivery_settings'] = delivery


### PR DESCRIPTION
Customer ID is properly recognized in normalizeEmailAddressOrUID if CUSTOMER_ID environment variable is set. This change then properly labels it as 'id', not 'email'.