### PR TITLE
Use explicit relative imports for Python 3

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -66,8 +66,8 @@ import oauth2client.file
 import oauth2client.tools
 from oauth2client.contrib.dictionary_storage import DictionaryStorage
 
-import utils
-from var import *
+from . import utils
+from .var import *
 
 # Finding path method varies between Python source, PyInstaller and StaticX
 if os.environ.get('STATICX_PROG_PATH', False):

--- a/src/gam.py
+++ b/src/gam.py
@@ -18,7 +18,7 @@
 # limitations under the License.
 """GAM is a command line tool which allows Administrators to control their G Suite domain and accounts.
 
-With GAM you can programatically create users, turn on/off services for users like POP and Forwarding and much more.
+With GAM you can programmatically create users, turn on/off services for users like POP and Forwarding and much more.
 For more information, see https://git.io/gam
 """
 
@@ -7131,7 +7131,7 @@ def getUserAttributes(i, cd, updateCmd):
         i += 1
         im['customProtocol'] = sys.argv[i]
       i += 1
-      # Backwards compatability: notprimary|primary on either side of IM address
+      # Backwards compatibility: notprimary|primary on either side of IM address
       myopt = sys.argv[i].lower()
       if myopt in ['notprimary', 'primary']:
         im['primary'] = myopt == 'primary'
@@ -9086,7 +9086,7 @@ def doUpdateGroup():
             currentMembersSet.add(current_email)
           else:
             currentMembersSet.add(_cleanConsumerAddress(current_email.lower(), currentMembersMap))
-# Compare incoming members and current memebers using the cleaned addresses; we actually add/remove with the original addresses
+# Compare incoming members and current members using the cleaned addresses; we actually add/remove with the original addresses
         to_add = [syncMembersMap.get(emailAddress, emailAddress) for emailAddress in syncMembersSet-currentMembersSet]
         to_remove = [currentMembersMap.get(emailAddress, emailAddress) for emailAddress in currentMembersSet-syncMembersSet]
         sys.stderr.write('Group: {0}, Will add {1} and remove {2} {3}s.\n'.format(group, len(to_add), len(to_remove), role))

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,7 @@
-import collections
 import re
 import sys
 from html.entities import name2codepoint
 from html.parser import HTMLParser
-from .var import GM_Globals, GM_WINDOWS, GM_SYS_ENCODING
 
 ONE_KILO_BYTES = 1000
 ONE_MEGA_BYTES = 1000000

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,16 +3,19 @@ import re
 import sys
 from html.entities import name2codepoint
 from html.parser import HTMLParser
-from var import GM_Globals, GM_WINDOWS, GM_SYS_ENCODING
+from .var import GM_Globals, GM_WINDOWS, GM_SYS_ENCODING
 
 ONE_KILO_BYTES = 1000
 ONE_MEGA_BYTES = 1000000
 ONE_GIGA_BYTES = 1000000000
 
+
 def convertUTF8(data):
   return data
 
+
 class _DeHTMLParser(HTMLParser):
+
   def __init__(self):
     HTMLParser.__init__(self)
     self.__text = []
@@ -21,14 +24,15 @@ class _DeHTMLParser(HTMLParser):
     self.__text.append(data)
 
   def handle_charref(self, name):
-    self.__text.append(chr(int(name[1:], 16)) if name.startswith('x') else chr(int(name)))
+    self.__text.append(
+        chr(int(name[1:], 16)) if name.startswith('x') else chr(int(name)))
 
   def handle_entityref(self, name):
     cp = name2codepoint.get(name)
     if cp:
       self.__text.append(chr(cp))
     else:
-      self.__text.append('&'+name)
+      self.__text.append('&' + name)
 
   def handle_starttag(self, tag, attrs):
     if tag == 'p':
@@ -51,7 +55,9 @@ class _DeHTMLParser(HTMLParser):
       self.__text.append('\n\n')
 
   def text(self):
-    return re.sub(r'\n{2}\n+', '\n\n', re.sub(r'\n +', '\n', ''.join(self.__text))).strip()
+    return re.sub(r'\n{2}\n+', '\n\n',
+                  re.sub(r'\n +', '\n', ''.join(self.__text))).strip()
+
 
 def dehtml(text):
   try:
@@ -64,8 +70,10 @@ def dehtml(text):
     print_exc(file=sys.stderr)
     return text
 
+
 def indentMultiLineText(message, n=0):
-  return message.replace('\n', '\n{0}'.format(' '*n)).rstrip()
+  return message.replace('\n', '\n{0}'.format(' ' * n)).rstrip()
+
 
 def formatFileSize(fileSize):
   if fileSize == 0:
@@ -73,10 +81,11 @@ def formatFileSize(fileSize):
   if fileSize < ONE_KILO_BYTES:
     return '1kb'
   if fileSize < ONE_MEGA_BYTES:
-    return '{0}kb'.format(fileSize//ONE_KILO_BYTES)
+    return '{0}kb'.format(fileSize // ONE_KILO_BYTES)
   if fileSize < ONE_GIGA_BYTES:
-    return '{0}mb'.format(fileSize//ONE_MEGA_BYTES)
-  return '{0}gb'.format(fileSize//ONE_GIGA_BYTES)
+    return '{0}mb'.format(fileSize // ONE_MEGA_BYTES)
+  return '{0}gb'.format(fileSize // ONE_GIGA_BYTES)
+
 
 def formatMilliSeconds(millis):
   seconds, millis = divmod(millis, 1000)


### PR DESCRIPTION
In Python 3, implicit relative imports within packages are no longer
available - only absolute imports and explicit relative imports are
supported. In addition, star imports (e.g. from x import *) are only
permitted in module level code.

See: https://www.python.org/dev/peps/pep-0404/#imports