### PR TITLE
Fix code to avoid trap when description is long

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -1518,8 +1518,7 @@ def buildGmailGAPIObject(user):
   return (userEmail, buildGAPIServiceObject('gmail', userEmail))
 
 def printPassFail(description, result):
-  padding = 80 - len(description) - 2
-  print(' {} {:>{padding}}'.format(description, result, padding=str(padding)))
+  print(' {0:74} {1}'.format(description, result))
 
 def doCheckServiceAccount(users):
   something_failed = False

--- a/src/gam.py
+++ b/src/gam.py
@@ -720,6 +720,8 @@ def SetGlobalVariables():
     GM_Globals[GM_CACHE_DISCOVERY_ONLY] = False
   return True
 
+TIME_OFFSET_UNITS = [('day', 86400), ('hour', 3600), ('minute', 60), ('second', 1)]
+
 def getLocalGoogleTimeOffset(testLocation='www.googleapis.com'):
   localUTC = datetime.datetime.now(datetime.timezone.utc)
   try:
@@ -729,23 +731,18 @@ def getLocalGoogleTimeOffset(testLocation='www.googleapis.com'):
     badhttp = _createHttpObj()
     badhttp.disable_ssl_certificate_validation = True
     googleUTC = dateutil.parser.parse(badhttp.request('https://'+testLocation, 'HEAD')[0]['date'])
-    offset = abs(localUTC-googleUTC).total_seconds()
-    days, remainder = divmod(offset, 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    timeoff = []
-    if days:
-      timeoff.append('%d days' % days)
-    if hours:
-      timeoff.append('%d hours' % hours)
-    if minutes:
-      timeoff.append('%d minutes' % minutes)
-    if seconds:
-      timeoff.append('%d seconds' % seconds)
-    nicetime = ', '.join(timeoff)
-    return (offset, nicetime)
   except (httplib2.ServerNotFoundError, RuntimeError, ValueError) as e:
     systemErrorExit(4, str(e))
+  offset = remainder = int(abs((localUTC-googleUTC).total_seconds()))
+  timeoff = []
+  for tou in TIME_OFFSET_UNITS:
+    uval, remainder = divmod(remainder, tou[1])
+    if uval:
+      timeoff.append('{0} {1}{2}'.format(uval, tou[0], 's' if uval != 1 else ''))
+  if not timeoff:
+    timeoff.append('less than 1 second')
+  nicetime = ', '.join(timeoff)
+  return (offset, nicetime)
 
 def doGAMCheckForUpdates(forceCheck=False):
 
@@ -835,9 +832,9 @@ def doGAMVersion(checkForArgs=True):
                             platform.platform(), platform.machine(), GM_Globals[GM_GAM_PATH]))
   if timeOffset:
     offset, nicetime = getLocalGoogleTimeOffset(testLocation)
-    print('Your computer is %s off from Google\'s time.' % (nicetime))
+    print(MESSAGE_YOUR_SYSTEM_TIME_DIFFERS_FROM_GOOGLE_BY % nicetime)
     if offset > MAX_LOCAL_GOOGLE_TIME_OFFSET:
-      systemErrorExit(4, 'Please fix your system clock.')
+      systemErrorExit(4, 'Please fix your system time.')
   if force_check:
     doGAMCheckForUpdates(forceCheck=True)
   if extended:
@@ -1529,7 +1526,7 @@ def doCheckServiceAccount(users):
   else:
     time_status = 'FAIL'
     something_failed = True
-  printPassFail('Your computer clock differs from Google by %s' % nicetime, time_status)
+  printPassFail(MESSAGE_YOUR_SYSTEM_TIME_DIFFERS_FROM_GOOGLE_BY % nicetime, time_status)
   oa2 = googleapiclient.discovery.build('oauth2', 'v1', _createHttpObj())
   print('Service Account Private Key Authentication:')
   # We are explicitly not doing DwD here, just confirming service account can auth
@@ -1589,7 +1586,7 @@ def doCheckServiceAccount(users):
       return
     user_domain = user[user.find('@')+1:]
     # Tack on email scope for more accurate checking
-    all_scopes.append('https://www.googleapis.com/auth/userinfo.email')
+    all_scopes.append(USERINFO_EMAIL_SCOPE)
     scopes_failed = '''Some scopes failed! Please go to:
 
 https://admin.google.com/%s/AdminHome?#OGX:ManageOauthClients

--- a/src/var.py
+++ b/src/var.py
@@ -933,6 +933,7 @@ MESSAGE_NO_TRANSFER_LACK_OF_DISK_SPACE = 'Cowardly refusing to perform migration
 MESSAGE_RESULTS_TOO_LARGE_FOR_GOOGLE_SPREADSHEET = 'Results are too large for Google Spreadsheets. Uploading as a regular CSV file.'
 MESSAGE_SERVICE_NOT_APPLICABLE = 'Service not applicable for this address: {0}. Please make sure service is enabled for user and run\n\ngam user <user> check serviceaccount\n\nfor further instructions'
 MESSAGE_INSTRUCTIONS_OAUTH2SERVICE_JSON = 'Please run\n\ngam create project\ngam user <user> check serviceaccount\n\nto create and configure a service account.'
+MESSAGE_YOUR_SYSTEM_TIME_DIFFERS_FROM_GOOGLE_BY = 'Your system time differs from Google by %s'
 # oauth errors
 OAUTH2_TOKEN_ERRORS = [
   'access_denied',


### PR DESCRIPTION

Force an error by corrupting scope.
```
$ gam user testuser1 check serviceaccount
Computer clock status:
 Your computer clock differs from Google by 0 seconds                       PASS
Service Account Private Key Authentication:
Traceback (most recent call last):
  File "/Users/admin/Documents/GoogleApps/GAMO/gam.py", line 14898, in <module>
    sys.exit(ProcessGAMCommand(sys.argv))
  File "/Users/admin/Documents/GoogleApps/GAMO/gam.py", line 14834, in ProcessGAMCommand
    doCheckServiceAccount(users)
  File "/Users/admin/Documents/GoogleApps/GAMO/gam.py", line 1552, in doCheckServiceAccount
    printPassFail('Authenticating...%s' % auth_error, sa_token_result)
  File "/Users/admin/Documents/GoogleApps/GAMO/gam.py", line 1522, in printPassFail
    print(' {} {:>{padding}}'.format(description, result, padding=str(padding)))
ValueError: Sign not allowed in string format specifier

$ gam user testuser1 check serviceaccount
Computer clock status:
 Your computer clock differs from Google by 1 seconds                       PASS
Service Account Private Key Authentication:
 Authenticating...invalid_scope: https://www.googleapis.com/auth/userinfo.emailx is not a valid audience string. FAIL
Domain-Wide Delegation authentication as testuser1@rdschool.org:
 https://mail.google.com/                                                   PASS
 https://www.googleapis.com/auth/activity                                   PASS
 https://www.googleapis.com/auth/apps.alerts                                PASS
 https://www.googleapis.com/auth/calendar                                   PASS
 https://www.googleapis.com/auth/drive                                      PASS
 https://www.googleapis.com/auth/gmail.settings.basic                       PASS
 https://www.googleapis.com/auth/gmail.settings.sharing                     PASS
 https://www.googleapis.com/auth/spreadsheets                               PASS


All scopes passed!
Service account 111991414055721632353 is fully authorized.
```