### PR TITLE
Fix #1006; Require regular user in same domain as admin user

### DIFF
--- a/src/gam-install.sh
+++ b/src/gam-install.sh
@@ -269,11 +269,17 @@ while $project_created; do
   read -p "Are you ready to authorize GAM to manage G Suite user data and settings? (yes or no) " yn
   case $yn in
     [Yy]*)
-      if [ "$regularuser" == "" ]; then
+      while true ; do
         read -p "Please enter the email address of a regular G Suite user: " regularuser
-      fi
+        if [ "${adminuser#*@}" == "${regularuser#*@}" ] ; then 
+          break 
+        fi
+        echo_red "Regular G Suite user must be in same domain as $adminuser"        
+      done
+
       echo_yellow "Great! Checking service account scopes.This will fail the first time. Follow the steps to authorize and retry. It can take a few minutes for scopes to PASS after they've been authorized in the admin console."
       "$target_dir/gam/gam" user $adminuser check serviceaccount
+      
       rc=$?
       if (( $rc == 0 )); then
         echo_green "Service account authorization complete."

--- a/src/gam-setup.bat
+++ b/src/gam-setup.bat
@@ -62,6 +62,10 @@
    )
 @echo(
 @set /p regularuser= "Please enter the email address of a regular G Suite user: "
+@if /I not "%adminemail:*@=%"=="%regularuser:*@=%" (
+@   echo Regular G Suite user must be in same domain as %adminemail%.
+@   goto saauth
+    )
 @echo Great! Checking service account scopes. This will fail the first time. Follow the steps to authorize and retry. It can take a few minutes for scopes to PASS after they've been authorized in the admin console.
 @gam user %regularuser% check serviceaccount
 @if not ERRORLEVEL 1 goto sadone


### PR DESCRIPTION
Addresses confusing situation in setup if user is not paying attention to which account s/he's logged into in the browser window used to authorize GAM to manage user data and settings.