### PR TITLE
Update code to allow recoveryphone to be cleared

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -7454,8 +7454,11 @@ def getUserAttributes(i, cd, updateCmd):
       i += 2
     elif myarg in ['recoveryphone']:
       body['recoveryPhone'] = sys.argv[i+1]
-      if body['recoveryPhone'] and body['recoveryPhone'][0] != '+':
-        body['recoveryPhone'] = '+' + body['recoveryPhone']
+      if body['recoveryPhone']:
+        if body['recoveryPhone'][0] != '+':
+          body['recoveryPhone'] = '+' + body['recoveryPhone']
+      else:
+        body['recoveryPhone'] = None
       i += 2
     elif myarg == 'clearschema':
       if not updateCmd:


### PR DESCRIPTION
An empty string leaves the recoveryphone as is, you have to set it to None to clear