### PR TITLE
Allow forks of jay0lee/GAM to use Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -209,7 +209,7 @@ script:
 - if [ "$VMTYPE" == "build" ]; then $gam version extended | grep TLSv1\.[23]; fi # Builds should default TLS 1.2 or 1.3 to Google
 - if [ "$VMTYPE" == "build" ]; then GAM_TLS_MIN_VERSION=TLSv1_2 $gam version extended location tls-v1-0.badssl.com:1010; [[ $? == 3 ]]; fi # expect fail since server doesn't support our TLS version
 - export jid="$(cut -d'.' -f2 <<<"$TRAVIS_JOB_NUMBER")"
-- if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ]; then export e2e=true; fi
+- if [ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_REPO_SLUG" == "jay0lee/GAM"]; then export e2e=true; fi
 - if [ "$e2e" = true ]; then export gam_user=gam-travis-$jid@pdl.jaylee.us; fi
 - if [ "$e2e" = true ]; then openssl aes-256-cbc -K $encrypted_ab10ec38326e_key -iv $encrypted_ab10ec38326e_iv -in travis/oauth2service.json.enc -out $gampath/oauth2service.json -d; fi
 - if [ "$e2e" = true ]; then cat travis/cfg_template.json | python travis/svars-write.py &> /dev/null; fi


### PR DESCRIPTION
Restrict e2e tests to only be run from jay0lee's repo, since they require certain secrets from that environment.

This enables forks to be setup with Travis to run all other applicable build tasks without having to modify the forked yaml.