### PR TITLE
Move transport customizations to their own module

### DIFF
--- a/src/gapi/__init___test.py
+++ b/src/gapi/__init___test.py
@@ -38,40 +38,6 @@ def create_http_error(status, reason, message):
   return gapi.googleapiclient.errors.HttpError(response, content_bytes)
 
 
-class CreateHttpTest(unittest.TestCase):
-
-  def setUp(self):
-    SetGlobalVariables()
-    super(CreateHttpTest, self).setUp()
-
-  def test_create_http_sets_default_values_on_http(self):
-    http = gapi.create_http()
-    self.assertIsNone(http.cache)
-    self.assertIsNone(http.timeout)
-    self.assertEqual(http.tls_minimum_version,
-                     gapi.GC_Values[gapi.GC_TLS_MIN_VERSION])
-    self.assertEqual(http.tls_maximum_version,
-                     gapi.GC_Values[gapi.GC_TLS_MAX_VERSION])
-    self.assertEqual(http.ca_certs, gapi.GC_Values[gapi.GC_CA_FILE])
-
-  def test_create_http_sets_tls_min_version(self):
-    http = gapi.create_http(override_min_tls=1111)
-    self.assertEqual(http.tls_minimum_version, 1111)
-
-  def test_create_http_sets_tls_max_version(self):
-    http = gapi.create_http(override_max_tls=9999)
-    self.assertEqual(http.tls_maximum_version, 9999)
-
-  def test_create_http_sets_cache(self):
-    fake_cache = {}
-    http = gapi.create_http(cache=fake_cache)
-    self.assertEqual(http.cache, fake_cache)
-
-  def test_create_http_sets_cache_timeout(self):
-    http = gapi.create_http(timeout=1234)
-    self.assertEqual(http.timeout, 1234)
-
-
 class GapiTest(unittest.TestCase):
 
   def setUp(self):

--- a/src/transport.py
+++ b/src/transport.py
@@ -1,0 +1,100 @@
+"""Methods related to network transport."""
+
+import google_auth_httplib2
+import httplib2
+
+from var import GAM_INFO
+from var import GC_CA_FILE
+from var import GC_TLS_MAX_VERSION
+from var import GC_TLS_MIN_VERSION
+from var import GC_Values
+
+
+def create_http(cache=None,
+                timeout=None,
+                override_min_tls=None,
+                override_max_tls=None):
+  """Creates a uniform HTTP transport object.
+
+  Args:
+    cache: The HTTP cache to use.
+    timeout: The cache timeout, in seconds.
+    override_min_tls: The minimum TLS version to require. If not provided, the
+      default is used.
+    override_max_tls: The maximum TLS version to require. If not provided, the
+      default is used.
+
+  Returns:
+    httplib2.Http with the specified options.
+  """
+  tls_minimum_version = override_min_tls if override_min_tls else GC_Values[
+      GC_TLS_MIN_VERSION]
+  tls_maximum_version = override_max_tls if override_max_tls else GC_Values[
+      GC_TLS_MAX_VERSION]
+  return httplib2.Http(
+      ca_certs=GC_Values[GC_CA_FILE],
+      tls_maximum_version=tls_maximum_version,
+      tls_minimum_version=tls_minimum_version,
+      cache=cache,
+      timeout=timeout)
+
+
+def create_request(http=None):
+  """Creates a uniform Request object with a default http, if not provided.
+
+  Args:
+    http: Optional httplib2.Http compatible object to be used with the request.
+      If not provided, a default HTTP will be used.
+
+  Returns:
+    Request: A google_auth_httplib2.Request compatible Request.
+  """
+  if not http:
+    http = create_http()
+  return Request(http)
+
+
+GAM_USER_AGENT = GAM_INFO
+
+
+def _force_user_agent(user_agent):
+  """Creates a decorator which can force a user agent in HTTP headers."""
+
+  def decorator(request_method):
+    """Wraps a request method to insert a user-agent in HTTP headers."""
+
+    def wrapped_request_method(*args, **kwargs):
+      """Modifies HTTP headers to include a specified user-agent."""
+      if kwargs.get('headers') is not None:
+        if kwargs['headers'].get('user-agent'):
+          if user_agent not in kwargs['headers']['user-agent']:
+            # Save the existing user-agent header and tack on our own.
+            kwargs['headers']['user-agent'] = '%s %s' % (
+                user_agent, kwargs['headers']['user-agent'])
+        else:
+          kwargs['headers']['user-agent'] = user_agent
+      else:
+        kwargs['headers'] = {'user-agent': user_agent}
+      return request_method(*args, **kwargs)
+
+    return wrapped_request_method
+
+  return decorator
+
+
+class Request(google_auth_httplib2.Request):
+  """A Request which forces a user agent."""
+
+  @_force_user_agent(GAM_USER_AGENT)
+  def __call__(self, *args, **kwargs):
+    """Inserts the GAM user-agent header in requests."""
+    return super(Request, self).__call__(*args, **kwargs)
+
+
+class AuthorizedHttp(google_auth_httplib2.AuthorizedHttp):
+  """An AuthorizedHttp which forces a user agent during requests."""
+
+  @_force_user_agent(GAM_USER_AGENT)
+  def request(self, *args, **kwargs):
+    """Inserts the GAM user-agent header in requests."""
+    return super(AuthorizedHttp, self).request(*args, **kwargs)

--- a/src/transport_test.py
+++ b/src/transport_test.py
@@ -28,12 +28,12 @@ class CreateHttpTest(unittest.TestCase):
     self.assertEqual(http.ca_certs, transport.GC_Values[transport.GC_CA_FILE])
 
   def test_create_http_sets_tls_min_version(self):
-    http = transport.create_http(override_min_tls=1111)
-    self.assertEqual(http.tls_minimum_version, 1111)
+    http = transport.create_http(override_min_tls='TLSv1_1')
+    self.assertEqual(http.tls_minimum_version, 'TLSv1_1')
 
   def test_create_http_sets_tls_max_version(self):
-    http = transport.create_http(override_max_tls=9999)
-    self.assertEqual(http.tls_maximum_version, 9999)
+    http = transport.create_http(override_max_tls='TLSv1_3')
+    self.assertEqual(http.tls_maximum_version, 'TLSv1_3')
 
   def test_create_http_sets_cache(self):
     fake_cache = {}

--- a/src/transport_test.py
+++ b/src/transport_test.py
@@ -1,0 +1,179 @@
+"""Tests for transport."""
+
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from gam import SetGlobalVariables
+import google_auth_httplib2
+import httplib2
+
+import transport
+
+
+class CreateHttpTest(unittest.TestCase):
+
+  def setUp(self):
+    SetGlobalVariables()
+    super(CreateHttpTest, self).setUp()
+
+  def test_create_http_sets_default_values_on_http(self):
+    http = transport.create_http()
+    self.assertIsNone(http.cache)
+    self.assertIsNone(http.timeout)
+    self.assertEqual(http.tls_minimum_version,
+                     transport.GC_Values[transport.GC_TLS_MIN_VERSION])
+    self.assertEqual(http.tls_maximum_version,
+                     transport.GC_Values[transport.GC_TLS_MAX_VERSION])
+    self.assertEqual(http.ca_certs, transport.GC_Values[transport.GC_CA_FILE])
+
+  def test_create_http_sets_tls_min_version(self):
+    http = transport.create_http(override_min_tls=1111)
+    self.assertEqual(http.tls_minimum_version, 1111)
+
+  def test_create_http_sets_tls_max_version(self):
+    http = transport.create_http(override_max_tls=9999)
+    self.assertEqual(http.tls_maximum_version, 9999)
+
+  def test_create_http_sets_cache(self):
+    fake_cache = {}
+    http = transport.create_http(cache=fake_cache)
+    self.assertEqual(http.cache, fake_cache)
+
+  def test_create_http_sets_cache_timeout(self):
+    http = transport.create_http(timeout=1234)
+    self.assertEqual(http.timeout, 1234)
+
+
+class TransportTest(unittest.TestCase):
+
+  def setUp(self):
+    self.mock_http = MagicMock(spec=httplib2.Http)
+    self.mock_response = MagicMock(spec=httplib2.Response)
+    self.mock_content = MagicMock()
+    self.mock_http.request.return_value = (self.mock_response,
+                                           self.mock_content)
+    self.mock_credentials = MagicMock()
+    self.test_uri = 'http://example.com'
+    super(TransportTest, self).setUp()
+
+  @patch.object(transport, 'create_http')
+  def test_create_request_uses_default_http(self, mock_create_http):
+    request = transport.create_request()
+    self.assertEqual(request.http, mock_create_http.return_value)
+
+  def test_create_request_uses_provided_http(self):
+    request = transport.create_request(http=self.mock_http)
+    self.assertEqual(request.http, self.mock_http)
+
+  def test_create_request_returns_request_with_forced_user_agent(self):
+    request = transport.create_request()
+    self.assertIsInstance(request, transport.Request)
+
+  def test_request_is_google_auth_httplib2_compatible(self):
+    request = transport.create_request()
+    self.assertIsInstance(request, google_auth_httplib2.Request)
+
+  def test_request_call_returns_response_content(self):
+    request = transport.Request(self.mock_http)
+    response = request(self.test_uri)
+    self.assertEqual(self.mock_response.status, response.status)
+    self.assertEqual(self.mock_content, response.data)
+
+  def test_request_call_forces_user_agent_no_provided_headers(self):
+    request = transport.Request(self.mock_http)
+
+    request(self.test_uri)
+    headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', headers)
+    self.assertIn(transport.GAM_USER_AGENT, headers['user-agent'])
+
+  def test_request_call_forces_user_agent_no_agent_in_headers(self):
+    request = transport.Request(self.mock_http)
+    fake_request_headers = {'some-header-thats-not-a-user-agent': 'someData'}
+
+    request(self.test_uri, headers=fake_request_headers)
+    final_headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', final_headers)
+    self.assertIn(transport.GAM_USER_AGENT, final_headers['user-agent'])
+    self.assertIn('some-header-thats-not-a-user-agent', final_headers)
+    self.assertEqual('someData',
+                     final_headers['some-header-thats-not-a-user-agent'])
+
+  def test_request_call_forces_user_agent_with_another_agent_in_headers(self):
+    request = transport.Request(self.mock_http)
+    headers_with_user_agent = {'user-agent': 'existing-user-agent'}
+
+    request(self.test_uri, headers=headers_with_user_agent)
+    final_headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', final_headers)
+    self.assertIn('existing-user-agent', final_headers['user-agent'])
+    self.assertIn(transport.GAM_USER_AGENT, final_headers['user-agent'])
+
+  def test_request_call_same_user_agent_already_in_headers(self):
+    request = transport.Request(self.mock_http)
+    same_user_agent_header = {'user-agent': transport.GAM_USER_AGENT}
+
+    request(self.test_uri, headers=same_user_agent_header)
+    final_headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', final_headers)
+    self.assertIn(transport.GAM_USER_AGENT, final_headers['user-agent'])
+    # Make sure the header wasn't duplicated
+    self.assertEqual(
+        len(transport.GAM_USER_AGENT), len(final_headers['user-agent']))
+
+  def test_authorizedhttp_is_google_auth_httplib2_compatible(self):
+    http = transport.AuthorizedHttp(self.mock_credentials)
+    self.assertIsInstance(http, google_auth_httplib2.AuthorizedHttp)
+
+  def test_authorizedhttp_request_returns_response_content(self):
+    http = transport.AuthorizedHttp(self.mock_credentials, http=self.mock_http)
+    response, content = http.request(self.test_uri)
+    self.assertEqual(self.mock_response, response)
+    self.assertEqual(self.mock_content, content)
+
+  def test_authorizedhttp_request_forces_user_agent_no_provided_headers(self):
+    authorized_http = transport.AuthorizedHttp(
+        self.mock_credentials, http=self.mock_http)
+    authorized_http.request(self.test_uri)
+    headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', headers)
+    self.assertIn(transport.GAM_USER_AGENT, headers['user-agent'])
+
+  def test_authorizedhttp_request_forces_user_agent_no_agent_in_headers(self):
+    authorized_http = transport.AuthorizedHttp(
+        self.mock_credentials, http=self.mock_http)
+    fake_request_headers = {'some-header-thats-not-a-user-agent': 'someData'}
+
+    authorized_http.request(self.test_uri, headers=fake_request_headers)
+    final_headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', final_headers)
+    self.assertIn(transport.GAM_USER_AGENT, final_headers['user-agent'])
+    self.assertIn('some-header-thats-not-a-user-agent', final_headers)
+    self.assertEqual('someData',
+                     final_headers['some-header-thats-not-a-user-agent'])
+
+  def test_authorizedhttp_request_forces_user_agent_with_another_agent_in_headers(
+      self):
+    authorized_http = transport.AuthorizedHttp(
+        self.mock_credentials, http=self.mock_http)
+    headers_with_user_agent = {'user-agent': 'existing-user-agent'}
+
+    authorized_http.request(self.test_uri, headers=headers_with_user_agent)
+    final_headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', final_headers)
+    self.assertIn('existing-user-agent', final_headers['user-agent'])
+    self.assertIn(transport.GAM_USER_AGENT, final_headers['user-agent'])
+
+  def test_authorizedhttp_request_same_user_agent_already_in_headers(self):
+    authorized_http = transport.AuthorizedHttp(
+        self.mock_credentials, http=self.mock_http)
+    same_user_agent_header = {'user-agent': transport.GAM_USER_AGENT}
+
+    authorized_http.request(self.test_uri, headers=same_user_agent_header)
+    final_headers = self.mock_http.request.call_args[1]['headers']
+    self.assertIn('user-agent', final_headers)
+    self.assertIn(transport.GAM_USER_AGENT, final_headers['user-agent'])
+    # Make sure the header wasn't duplicated
+    self.assertEqual(
+        len(transport.GAM_USER_AGENT), len(final_headers['user-agent']))


### PR DESCRIPTION
This helps to accomplish a few things:
1) Makes the forced user-agent customization on HTTP requests a bit
clearer by subclassing the targeted objects (as opposed to hiding the
behavior behind a forced override of the google_auth_httplib2 object
methods)
2) Standardizes the creation of HTTP objects. These objects can still
largely be customized, but using a single creation mechanism will
standardize a default and streamline creation, thereby decreasing the
code that would otherwise be replicated in the caller
3) Moves create_http() to a more general purpose module, since it will
likely be used by more than gapi-related methods.

This change continues work on jay0lee/GAM#147