### PR TITLE
Update gam-install.sh to set .profile on a Mac as a default

### DIFF
--- a/src/gam-install.sh
+++ b/src/gam-install.sh
@@ -52,7 +52,7 @@ done
 target_dir=${target_dir%/}
 
 update_profile() {
-	[ -f "$1" ] || return 1
+	[ $2 -eq 1 ] || [ -f "$1" ] || return 1
 
 	grep -F "$alias_line" "$1" > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
@@ -251,9 +251,9 @@ fi
 if [ "$update_profile" = true ]; then
   alias_line="gam() { \"$target_dir/gam/gam\" \"\$@\" ; }"
   if [ "$gamos" == "linux" ]; then
-    update_profile "$HOME/.bashrc" || update_profile "$HOME/.bash_profile"
+    update_profile "$HOME/.bash_aliases" 0 || update_profile "$HOME/.bash_profile" 0 || update_profile "$HOME/.bashrc" 0 || update_profile "$HOME/.zshrc" 0
   elif [ "$gamos" == "macos" ]; then
-    update_profile "$HOME/.profile" || update_profile "$HOME/.bash_profile"
+    update_profile "$HOME/.bash_aliases" 0 || update_profile "$HOME/.bash_profile" 0 || update_profile "$HOME/.bashrc" 0 || update_profile "$HOME/.zshrc" 0 || update_profile "$HOME/.profile" 1
   fi
 else
   echo_yellow "skipping profile update."


### PR DESCRIPTION
This is most useful on Mac OS where there are often no places to put the gam alias. This will set an alias in .profile by default; this works for bash an zsh.

In my version I update the profile even on an upgrade only to handle the case where the user is installing gam on a second computer and uses -l to just do an upgrade. They'll just copy the authorization files from the existing installation. Do you want this change?