### PR TITLE
Improve error handling when invalid report is entered

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -880,6 +880,25 @@ gam update resoldsubscription <CustomerID> <SKUID>
 gam delete resoldsubscription <CustomerID> <SKUID> cancel|downgrade|transfer_to_direct
 gam info resoldsubscriptions <CustomerID> [customer_auth_token <String>]
 
+<ActivityApplicationName> ::=
+        access|accesstransparency|
+        admin|
+        calendar|calendars|
+	chat|
+        drive|doc|docs|
+        enterprisegroups|groupsenterprise|
+	gcp|
+        google+|gplus|
+        group|groups|
+        hangoutsmeet|meet|
+	jamboard|
+        login|logins|
+        mobile|
+        oauthtoken|token|tokens|
+        rules|
+        saml|
+        useraccounts
+
 <ReportsApp> ::=
 	accounts|
 	app_maker|
@@ -899,7 +918,7 @@ gam report users|user [todrive] [date <Date>] [fulldatarequired all|<ReportsAppL
 	[(user <UserItem>)|(orgunit|org|ou <OrgUnitPath>)] [filter|filters <String>] [fields|parameters <String>]
 gam report customers|customer|domain [todrive] [date <Date>] [fulldatarequired all|<ReportsAppList>]
 	[fields|parameters <String>]
-gam report admin|calendar|calendars|drive|docs|doc|groups|group|logins|login|mobile|tokens|token [todrive]
+gam report <ActivityApplicationName> [todrive]
 	[start <Time>] [end <Time>] [(user all|<UserItem>)] [event <String>] [filter|filters <String>] [ip <String>]
 
 gam create admin <UserItem> <RoleItem> customer|(org_unit <OrgUnitItem>)

--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -881,23 +881,23 @@ gam delete resoldsubscription <CustomerID> <SKUID> cancel|downgrade|transfer_to_
 gam info resoldsubscriptions <CustomerID> [customer_auth_token <String>]
 
 <ActivityApplicationName> ::=
-        access|accesstransparency|
-        admin|
-        calendar|calendars|
+	access|accesstransparency|
+	admin|
+	calendar|calendars|
 	chat|
-        drive|doc|docs|
-        enterprisegroups|groupsenterprise|
+	drive|doc|docs|
+	enterprisegroups|groupsenterprise|
 	gcp|
-        google+|gplus|
-        group|groups|
-        hangoutsmeet|meet|
+	google+|gplus|
+	group|groups|
+	hangoutsmeet|meet|
 	jamboard|
-        login|logins|
-        mobile|
-        oauthtoken|token|tokens|
-        rules|
-        saml|
-        useraccounts
+	login|logins|
+	mobile|
+	oauthtoken|token|tokens|
+	rules|
+	saml|
+	useraccounts
 
 <ReportsApp> ::=
 	accounts|

--- a/src/gam.py
+++ b/src/gam.py
@@ -1219,6 +1219,7 @@ REPORT_CHOICE_MAP = {
   'admin': 'admin',
   'calendar': 'calendar',
   'calendars': 'calendar',
+  'chat': 'chat',
   'customer': 'customer',
   'customers': 'customer',
   'doc': 'drive',

--- a/src/gam.py
+++ b/src/gam.py
@@ -1216,45 +1216,31 @@ def _checkFullDataAvailable(warnings, tryDate, fullDataRequired):
 REPORT_CHOICE_MAP = {
   'access': 'access_transparency',
   'accesstransparency': 'access_transparency',
-  'admin': 'admin',
-  'calendar': 'calendar',
   'calendars': 'calendar',
-  'chat': 'chat',
-  'customer': 'customer',
   'customers': 'customer',
   'doc': 'drive',
   'docs': 'drive',
   'domain': 'customer',
-  'drive': 'drive',
   'enterprisegroups': 'groups_enterprise',
-  'gcp': 'gcp',
-  'gplus': 'gplus',
   'google+': 'gplus',
   'group': 'groups',
-  'groups': 'groups',
   'groupsenterprise': 'groups_enterprise',
   'hangoutsmeet': 'meet',
-  'jamboard': 'jamboard',
-  'login': 'login',
   'logins': 'login',
-  'meet': 'meet',
-  'mobile': 'mobile',
   'oauthtoken': 'token',
-  'rules': 'rules',
-  'saml': 'saml',
-  'token': 'token',
   'tokens': 'token',
-  'user': 'user',
   'users': 'user',
   'useraccounts': 'user_accounts',
   }
 
 def showReport():
   rep = buildGAPIObject('reports')
-  report = sys.argv[2].lower().replace('_', '')
-  if report not in REPORT_CHOICE_MAP:
-    controlflow.expected_argument_exit("report", ", ".join(REPORT_CHOICE_MAP), report)
-  report = REPORT_CHOICE_MAP[report]
+  report = sys.argv[2].lower()
+  if report.replace('_', '') in REPORT_CHOICE_MAP:
+    report = REPORT_CHOICE_MAP[report.replace('_', '')]
+  valid_apps = _getEnumValuesMinusUnspecified(rep._rootDesc['resources']['activities']['methods']['list']['parameters']['applicationName']['enum'])
+  if report not in valid_apps:
+    controlflow.expected_argument_exit("report", ", ".join(valid_apps), report)
   customerId = GC_Values[GC_CUSTOMER_ID]
   if customerId == MY_CUSTOMER:
     customerId = None
@@ -11582,7 +11568,6 @@ def doCreateAlertFeedback():
   alertId = sys.argv[3]
   body = {'type': sys.argv[4].upper()}
   if body['type'] not in valid_types:
-###
     controlflow.system_error_exit(2, f'{body["type"]} is not a valid feedback value, expected one of: {", ".join(valid_types)}')
   gapi.call(ac.alerts().feedback(), 'create', alertId=alertId, body=body)
 

--- a/src/gam.py
+++ b/src/gam.py
@@ -1215,6 +1215,7 @@ def _checkFullDataAvailable(warnings, tryDate, fullDataRequired):
 
 REPORT_CHOICE_MAP = {
   'access': 'access_transparency',
+  'accesstransparency': 'access_transparency',
   'calendars': 'calendar',
   'customers': 'customer',
   'doc': 'drive',
@@ -1223,11 +1224,13 @@ REPORT_CHOICE_MAP = {
   'enterprisegroups': 'groups_enterprise',
   'google+': 'gplus',
   'group': 'groups',
+  'groupsenterprise': 'groups_enterprise',
   'hangoutsmeet': 'meet',
   'logins': 'login',
   'oauthtoken': 'token',
   'tokens': 'token',
   'users': 'user',
+  'useraccounts': 'user_accounts',
   }
 
 def showReport():

--- a/src/gam.py
+++ b/src/gam.py
@@ -1215,7 +1215,6 @@ def _checkFullDataAvailable(warnings, tryDate, fullDataRequired):
 
 REPORT_CHOICE_MAP = {
   'access': 'access_transparency',
-  'accesstransparency': 'access_transparency',
   'calendars': 'calendar',
   'customers': 'customer',
   'doc': 'drive',
@@ -1224,13 +1223,11 @@ REPORT_CHOICE_MAP = {
   'enterprisegroups': 'groups_enterprise',
   'google+': 'gplus',
   'group': 'groups',
-  'groupsenterprise': 'groups_enterprise',
   'hangoutsmeet': 'meet',
   'logins': 'login',
   'oauthtoken': 'token',
   'tokens': 'token',
   'users': 'user',
-  'useraccounts': 'user_accounts',
   }
 
 def showReport():

--- a/src/gam.py
+++ b/src/gam.py
@@ -1236,8 +1236,7 @@ REPORT_CHOICE_MAP = {
 def showReport():
   rep = buildGAPIObject('reports')
   report = sys.argv[2].lower()
-  if report.replace('_', '') in REPORT_CHOICE_MAP:
-    report = REPORT_CHOICE_MAP[report.replace('_', '')]
+  report = REPORT_CHOICE_MAP.get(report.replace('_', ''), report)
   valid_apps = _getEnumValuesMinusUnspecified(rep._rootDesc['resources']['activities']['methods']['list']['parameters']['applicationName']['enum'])
   if report not in valid_apps:
     controlflow.expected_argument_exit("report", ", ".join(valid_apps), report)

--- a/src/gam.py
+++ b/src/gam.py
@@ -1213,9 +1213,47 @@ def _checkFullDataAvailable(warnings, tryDate, fullDataRequired):
           return (-1, tryDate)
   return (1, tryDate)
 
+REPORT_CHOICE_MAP = {
+  'access': 'access_transparency',
+  'accesstransparency': 'access_transparency',
+  'admin': 'admin',
+  'calendar': 'calendar',
+  'calendars': 'calendar',
+  'customer': 'customer',
+  'customers': 'customer',
+  'doc': 'drive',
+  'docs': 'drive',
+  'domain': 'customer',
+  'drive': 'drive',
+  'enterprisegroups': 'groups_enterprise',
+  'gcp': 'gcp',
+  'gplus': 'gplus',
+  'google+': 'gplus',
+  'group': 'groups',
+  'groups': 'groups',
+  'groupsenterprise': 'groups_enterprise',
+  'hangoutsmeet': 'meet',
+  'jamboard': 'jamboard',
+  'login': 'login',
+  'logins': 'login',
+  'meet': 'meet',
+  'mobile': 'mobile',
+  'oauthtoken': 'token',
+  'rules': 'rules',
+  'saml': 'saml',
+  'token': 'token',
+  'tokens': 'token',
+  'user': 'user',
+  'users': 'user',
+  'useraccounts': 'user_accounts',
+  }
+
 def showReport():
   rep = buildGAPIObject('reports')
-  report = sys.argv[2].lower()
+  report = sys.argv[2].lower().replace('_', '')
+  if report not in REPORT_CHOICE_MAP:
+    controlflow.expected_argument_exit("report", ", ".join(REPORT_CHOICE_MAP), report)
+  report = REPORT_CHOICE_MAP[report]
   customerId = GC_Values[GC_CUSTOMER_ID]
   if customerId == MY_CUSTOMER:
     customerId = None
@@ -1265,7 +1303,7 @@ def showReport():
       i += 1
     else:
       controlflow.invalid_argument_exit(sys.argv[i], "gam report")
-  if report in ['users', 'user']:
+  if report == 'user':
     while True:
       try:
         if fullDataRequired is not None:
@@ -1307,7 +1345,7 @@ def showReport():
           row[name] = ''
       csvRows.append(row)
     writeCSVfile(csvRows, titles, f'User Reports - {tryDate}', to_drive)
-  elif report in ['customer', 'customers', 'domain']:
+  elif report == 'customer':
     while True:
       try:
         if fullDataRequired is not None:
@@ -1372,16 +1410,6 @@ def showReport():
       csvRows.append(app)
     writeCSVfile(csvRows, titles, f'Customer Report - {tryDate}', todrive=to_drive)
   else:
-    if report in ['doc', 'docs']:
-      report = 'drive'
-    elif report in ['calendars']:
-      report = 'calendar'
-    elif report == 'logins':
-      report = 'login'
-    elif report == 'tokens':
-      report = 'token'
-    elif report == 'group':
-      report = 'groups'
     page_message = gapi.got_total_items_msg('Activities', '...\n')
     activities = gapi.get_all_pages(rep.activities(), 'list', 'items',
                                     page_message=page_message,


### PR DESCRIPTION
Replace this:
```
$ gam report foo
Traceback (most recent call last):
  File "/Users/admin/Documents/GoogleApps/GAMO/gam.py", line 14755, in <module>
    sys.exit(ProcessGAMCommand(sys.argv))
  File "/Users/admin/Documents/GoogleApps/GAMO/gam.py", line 14391, in ProcessGAMCommand
    showReport()
  File "/Users/admin/Documents/GoogleApps/GAMO/gam.py", line 1386, in showReport
    activities = gapi.get_all_pages(rep.activities(), 'list', 'items',
  File "/Users/admin/Documents/GoogleApps/GAMO/gapi/__init__.py", line 254, in get_all_pages
    page_key = _get_max_page_size_for_api_call(service, function, **kwargs)
  File "/Users/admin/Documents/GoogleApps/GAMO/gapi/__init__.py", line 157, in _get_max_page_size_for_api_call
    api_id = method(**kwargs).methodId
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/googleapiclient/discovery.py", line 741, in method
    raise TypeError(
TypeError: Parameter "applicationName" value "foo" does not match the pattern "(admin)|(calendar)|(drive)|(login)|(mobile)|(token)|(groups)|(saml)|(chat)|(gplus)|(rules)|(jamboard)|(meet)|(user_accounts)|(access_transparency)|(groups_enterprise)|(gcp)"
```
with this:
```
$ gam report foo

ERROR: report must be one of access, accesstransparency, admin, calendar, calendars, customer, customers, doc, docs, domain, drive, enterprisegroups, gcp, gplus, google+, group, groups, groupsenterprise, hangoutsmeet, jamboard, login, logins, meet, mobile,\
 oauthtoken, rules, saml, token, tokens, user, users, useraccounts; got foo

```