### PR TITLE
Fix bug in checking for32/64 bit mismatch

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -750,7 +750,7 @@ def doGAMVersion(checkForArgs=True):
          f'{getOSPlatform()} {platform.machine()}\n'
          f'Path: {GM_Globals[GM_GAM_PATH]}'))
   if sys.platform.startswith('win') and \
-     cpu_bits != 32 and \
+     cpu_bits == 32 and \
      platform.machine().find('64') != -1:
     print(MESSAGE_UPDATE_GAM_TO_64BIT)
   if timeOffset:


### PR DESCRIPTION
```
c:\GamTest>gam version
GAM 4.98 - https://git.io/gam
Jay Lee <jay0lee@gmail.com>
Python 3.8.1 64-bit final
google-api-python-client 1.7.11
Windows 10 10.0.18362   AMD64
Path: c:\GamTest
You're running a 32-bit version of GAM on a 64-bit version of Windows, upgrade to a windows-x86_64 version of GAM

c:\GamTest>gam version
GAM 4.98 - https://git.io/gam
Jay Lee <jay0lee@gmail.com>
Python 3.8.1 32-bit final
google-api-python-client 1.7.11
Windows 10 10.0.18362   AMD64
Path: c:\GamTest
```