### PR TITLE
Changed code to shorten the public key lifetime in `gam create|user project` to stay within a Google limit.

### DIFF
--- a/src/gam.py
+++ b/src/gam.py
@@ -6716,7 +6716,7 @@ def _generatePrivateKeyAndPublicCert(client_id, key_size):
   builder = builder.issuer_name(x509.Name([
         x509.NameAttribute(NameOID.COMMON_NAME, client_id)]))
   not_valid_before = datetime.datetime.today() - datetime.timedelta(days=1)
-  not_valid_after = datetime.datetime.today() + datetime.timedelta(days=365*10)
+  not_valid_after = datetime.datetime.today() + datetime.timedelta(days=365*10-1)
   builder = builder.not_valid_before(not_valid_before)
   builder = builder.not_valid_after(not_valid_after)
   builder = builder.serial_number(x509.random_serial_number())


### PR DESCRIPTION
400 - The given public key has a lifetime of 315,446,400 seconds, which is longer than the max allowed lifetime of 315,360,000 seconds as specified in resource settings.