### PR TITLE
This will make GAM and GAMADV-XTD3 consistent

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -1248,7 +1248,7 @@ gam reopen vaultmatter|matter <MatterItem>
 gam delete vaultmatter|matter <MatterItem>
 gam undelete vaultmatter|matter <MatterItem>
 gam info vaultmatter|matter <MatterItem>
-gam print vaultmatters|matters [todrive] [basic|full]
+gam print vaultmatters|matters [todrive] [basic|full] [matterstate open|closed|deleted]
 
 gam <UserTypeEntity> delete|del asp|asps|applicationspecificpasswords all|<ASPIDList>
 gam <UserTypeEntity> show asps|asp|applicationspecificpasswords

--- a/src/gapi/vault.py
+++ b/src/gapi/vault.py
@@ -663,7 +663,7 @@ def printMatters():
         elif myarg in PROJECTION_CHOICES_MAP:
             view = PROJECTION_CHOICES_MAP[myarg]
             i += 1
-        elif myarg == 'state':
+        elif myarg == 'matterstate':
             valid_states = gapi.get_enum_values_minus_unspecified(
                 v._rootDesc['schemas']['Matter']['properties']['state'][
                     'enum'])


### PR DESCRIPTION

In my version you can specify matter states as above to select which to display, and you can specify fields to display, state being one of then. Using matterstate disambiguates what you're trying to do.

Thanks