### PR TITLE
Make get_token_value refresh credentials on its own, when necessary

### DIFF
--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -23,8 +23,4 @@ def get_admin_credentials_filename():
 def get_admin_credentials():
     """Gets oauth.Credentials that are authenticated as the domain's admin user."""
     credential_file = get_admin_credentials_filename()
-    creds = oauth.Credentials.from_credentials_file(credential_file)
-    if creds.expired:
-        request = transport.create_request()
-        creds.refresh(request)
-    return creds
+    return oauth.Credentials.from_credentials_file(credential_file)

--- a/src/auth/oauth.py
+++ b/src/auth/oauth.py
@@ -382,7 +382,12 @@ class Credentials(google.oauth2.credentials.Credentials):
     """
     if not self.id_token:
       raise CredentialsError('Failed to fetch token data. No id_token present.')
+
     request = transport.create_request()
+    if self.expired:
+      # The id_token needs to be unexpired, in order to request data about it.
+      self.refresh(request)
+
     self._id_token_data = google.oauth2.id_token.verify_oauth2_token(
         self.id_token, request)
 

--- a/src/auth/oauth_test.py
+++ b/src/auth/oauth_test.py
@@ -336,6 +336,26 @@ class CredentialsTest(unittest.TestCase):
         id_token_data=self.fake_token_data)
     self.assertEqual('Unknown', creds.get_token_value('unknown-field'))
 
+  @patch.object(oauth.google.oauth2.id_token, 'verify_oauth2_token')
+  def test_get_token_value_credentials_expired(self, mock_verify_oauth2_token):
+    mock_verify_oauth2_token.return_value = {'fetched-field': 'fetched-value'}
+    time_earlier_than_now = datetime.datetime.now() - datetime.timedelta(
+        minutes=5)
+    creds = oauth.Credentials(
+        token=self.fake_token,
+        client_id=self.fake_client_id,
+        client_secret=self.fake_client_secret,
+        expiry=time_earlier_than_now,
+        id_token=self.fake_id_token,
+        id_token_data=None)
+    self.assertTrue(creds.expired)
+    creds.refresh = MagicMock()
+
+    token_value = creds.get_token_value('fetched-field')
+
+    self.assertEqual('fetched-value', token_value)
+    self.assertTrue(creds.refresh.called)
+
   def test_to_json_contains_all_required_fields(self):
     creds = oauth.Credentials(
         token=self.fake_token,
@@ -585,7 +605,7 @@ class ShortUrlFlowTest(unittest.TestCase):
 
   @patch.object(oauth.google_auth_oauthlib.flow.InstalledAppFlow,
                 'authorization_url')
-  @unittest.skip("disable short url tests temporarily.")
+  @unittest.skip('disable short url tests temporarily.')
   def test_shorturlflow_returns_shortened_url(self, mock_super_auth_url):
     url_flow = oauth._ShortURLFlow.from_client_config(
         self.fake_client_config, scopes=self.fake_scopes)
@@ -609,7 +629,7 @@ class ShortUrlFlowTest(unittest.TestCase):
 
   @patch.object(oauth.google_auth_oauthlib.flow.InstalledAppFlow,
                 'authorization_url')
-  @unittest.skip("disable short url tests temporarily.")
+  @unittest.skip('disable short url tests temporarily.')
   def test_shorturlflow_falls_back_to_long_url_on_request_error(
       self, mock_super_auth_url):
     url_flow = oauth._ShortURLFlow.from_client_config(
@@ -625,7 +645,7 @@ class ShortUrlFlowTest(unittest.TestCase):
 
   @patch.object(oauth.google_auth_oauthlib.flow.InstalledAppFlow,
                 'authorization_url')
-  @unittest.skip("disable short url tests temporarily.")
+  @unittest.skip('disable short url tests temporarily.')
   def test_shorturlflow_falls_back_to_long_url_on_non_200_response_status(
       self, mock_super_auth_url):
     url_flow = oauth._ShortURLFlow.from_client_config(
@@ -644,7 +664,7 @@ class ShortUrlFlowTest(unittest.TestCase):
 
   @patch.object(oauth.google_auth_oauthlib.flow.InstalledAppFlow,
                 'authorization_url')
-  @unittest.skip("disable short url tests temporarily.")
+  @unittest.skip('disable short url tests temporarily.')
   def test_shorturlflow_falls_back_to_long_url_on_bad_json_response(
       self, mock_super_auth_url):
     url_flow = oauth._ShortURLFlow.from_client_config(
@@ -663,7 +683,7 @@ class ShortUrlFlowTest(unittest.TestCase):
 
   @patch.object(oauth.google_auth_oauthlib.flow.InstalledAppFlow,
                 'authorization_url')
-  @unittest.skip("disable short url tests temporarily.")
+  @unittest.skip('disable short url tests temporarily.')
   def test_shorturlflow_falls_back_to_long_url_on_empty_short_url_field(
       self, mock_super_auth_url):
     url_flow = oauth._ShortURLFlow.from_client_config(

--- a/src/transport.py
+++ b/src/transport.py
@@ -27,13 +27,16 @@ def create_http(cache=None,
   Returns:
     httplib2.Http with the specified options.
   """
-  tls_minimum_version = override_min_tls if override_min_tls else GC_Values[GC_TLS_MIN_VERSION]
-  tls_maximum_version = override_max_tls if override_max_tls else GC_Values[GC_TLS_MAX_VERSION]
-  httpObj = httplib2.Http(ca_certs=GC_Values[GC_CA_FILE],
-                          tls_maximum_version=tls_maximum_version,
-                          tls_minimum_version=tls_minimum_version,
-                          cache=cache,
-                          timeout=timeout)
+  tls_minimum_version = override_min_tls if override_min_tls else GC_Values.get(
+      GC_TLS_MIN_VERSION)
+  tls_maximum_version = override_max_tls if override_max_tls else GC_Values.get(
+      GC_TLS_MAX_VERSION)
+  httpObj = httplib2.Http(
+      ca_certs=GC_Values.get(GC_CA_FILE),
+      tls_maximum_version=tls_maximum_version,
+      tls_minimum_version=tls_minimum_version,
+      cache=cache,
+      timeout=timeout)
   httpObj.redirect_codes = set(httpObj.redirect_codes) - {308}
   return httpObj
 
@@ -68,7 +71,9 @@ def _force_user_agent(user_agent):
         if kwargs['headers'].get('user-agent'):
           if user_agent not in kwargs['headers']['user-agent']:
             # Save the existing user-agent header and tack on our own.
-            kwargs['headers']['user-agent'] = f'{user_agent} {kwargs["headers"]["user-agent"]}'
+            kwargs['headers']['user-agent'] = (
+                f'{user_agent} '
+                f'{kwargs["headers"]["user-agent"]}')
         else:
           kwargs['headers']['user-agent'] = user_agent
       else:


### PR DESCRIPTION
Any other transaction utilizing credentials will already refresh them,
as necessary, through the use of AuthorizedHttp. `get_token_value` is
one unique case where we're not actually attaching the credentials to
the HTTP request, but rather using one if its attributes as the payload.
The request, itself, is unauthenticated, so it doesn't know to refresh
on its own. Rather, the caller needs to make sure that the id_token
payload is for a currently-valid set of credentials.

Folllow-up to quick-fix for #1149 