### PR TITLE
Add pre-commit config for formatting and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+    python: python3.7
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-docstring-first
+    -   id: name-tests-test
+    -   id: requirements-txt-fixer
+
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.29.0
+    hooks:
+    -   id: yapf
+        args: [--style=google, --in-place]
+
+-   repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.4.4
+    hooks:
+    -   id: pylint
+        args: [--output-format=colorized]

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,0 +1,7 @@
+# This file contains all requirements needed for GAM development work
+
+# Include all build requirements
+-r requirements.txt
+
+# Dev-specific requirements
+pre-commit

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,10 +1,10 @@
 cryptography
-python-dateutil
 distro; sys_platform == 'linux'
 filelock
 google-api-python-client>=1.7.10
-google-auth>=1.11.2
 google-auth-httplib2
 google-auth-oauthlib>=0.4.1
+google-auth>=1.11.2
 httplib2>=0.17.0
 passlib>=1.7.2; sys_platform == 'win32'
+python-dateutil


### PR DESCRIPTION
Adds a pre-commit config that runs several fixers, including YAPF with
"google" style and pylint for static analysis

Note: This is a local pre-commit only. Running a GitHub action to perform this action on PRs may be configurable.

Makes progress on #874 to define a style guide. May still need to setup a GitHub action to enforce on PRs. 