### PR TITLE
include includeDerivedMembership option for group sync

### DIFF
--- a/src/gam/__init__.py
+++ b/src/gam/__init__.py
@@ -12163,7 +12163,7 @@ def getUsersToModify(entity_type=None,
                                      fields=listFields)
         users = []
         for member in members:
-            if ((not groupUserMembersOnly) or
+            if ((not groupUserMembersOnly and not includeDerivedMembership) or
                 (member['type'] == 'USER')) and _checkMemberRoleIsSuspended(
                     member, validRoles, checkSuspended):
                 users.append(member.get('email', member['id']))

--- a/src/gam/__init__.py
+++ b/src/gam/__init__.py
@@ -12118,6 +12118,7 @@ def getUsersToModify(entity_type=None,
                      checkSuspended=None,
                      groupUserMembersOnly=True):
     got_uids = False
+    includeDerivedMembership = False
     if entity_type is None:
         entity_type = sys.argv[1].lower()
     if entity is None:
@@ -12129,11 +12130,13 @@ def getUsersToModify(entity_type=None,
         ]
     elif entity_type == 'users':
         users = entity.replace(',', ' ').split()
-    elif entity_type in ['group', 'group_ns', 'group_susp']:
+    elif entity_type in ['group', 'group_ns', 'group_susp','group_inde']:
         if entity_type == 'group_ns':
             checkSuspended = False
         elif entity_type == 'group_susp':
             checkSuspended = True
+        if entity_type == 'group_inde':
+            includeDerivedMembership = True
         got_uids = True
         group = entity
         if member_type is None:
@@ -12156,6 +12159,7 @@ def getUsersToModify(entity_type=None,
                                      page_message=page_message,
                                      groupKey=group,
                                      roles=listRoles,
+                                     includeDerivedMembership=includeDerivedMembership,
                                      fields=listFields)
         users = []
         for member in members:


### PR DESCRIPTION
In command:
gam course xxx sync students|teachers group yyyy@ddddd.ddd.dd
I add alternative option "group_inde" (INclude DErived). Just a sugestion name, be free for change.
gam course xxx sync students|teachers group_inde yyyy@ddddd.ddd.dd