### PR TITLE
Fix issue with zsh not loading gam

### DIFF
--- a/src/gam-install.sh
+++ b/src/gam-install.sh
@@ -240,7 +240,7 @@ fi
 
 # Update profile to add gam command
 if [ "$update_profile" = true ]; then
-  alias_line="gam() { \"$target_dir/gam/gam\" \"\$@\" ; }"
+  alias_line="function gam() { \"$target_dir/gam/gam\" \"\$@\" ; }"
   if [ "$gamos" == "linux" ]; then
     update_profile "$HOME/.bash_aliases" 0 || update_profile "$HOME/.bash_profile" 0 || update_profile "$HOME/.bashrc" 0
     update_profile "$HOME/.zshrc" 0


### PR DESCRIPTION
When Terminal opened I received the following error...
```
Last login: Fri Sep 18 13:00:55 on ttys000
/Users/sean/.zshrc:104: defining function based on alias `gam'
/Users/sean/.zshrc:104: parse error near `()'
```

Added function before gam in the .zshrc file.