### PR TITLE
docs: fix simple typo, sysyem -> system

### DIFF
--- a/src/gam/controlflow.py
+++ b/src/gam/controlflow.py
@@ -66,7 +66,7 @@ def csv_field_error_exit(field_name, field_names):
 
 
 def invalid_json_exit(file_name):
-    """Raises a sysyem exit when invalid JSON content is encountered."""
+    """Raises a system exit when invalid JSON content is encountered."""
     system_error_exit(17, MESSAGE_INVALID_JSON.format(file_name))
 
 


### PR DESCRIPTION
There is a small typo in src/gam/controlflow.py.

Should read `system` rather than `sysyem`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md