### PR TITLE
Bump google-api-python-client requirements to v2.0.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 cryptography
 distro; sys_platform == 'linux'
 filelock
-google-api-python-client>=1.7.10
+google-api-python-client>=2.0.0
 google-auth-httplib2
 google-auth-oauthlib>=0.4.1
 google-auth>=1.11.2


### PR DESCRIPTION
We pass static_discovery keyword arg that got introduced in v2 only.

With v1 we are hitting an exception:

```
$ gam info domain
Traceback (most recent call last):
  File "/PREFIX/GAM/src/gam.py", line 11, in <module>
    main(sys.argv)
  File "/PREFIX/GAM/src/gam/__main__.py", line 45, in main
    sys.exit(gam.ProcessGAMCommand(sys.argv))
  File "/PREFIX/GAM/src/gam/__init__.py", line 11291, in ProcessGAMCommand
    gapi_directory_domains.info()
  File "/PREFIX/GAM/src/gam/gapi/directory/domains.py", line 25, in info
    gapi_directory_customer.doGetCustomerInfo()
  File "/PREFIX/GAM/src/gam/gapi/directory/customer.py", line 18, in doGetCustomerInfo
    cd = gapi_directory.build()
  File "/PREFIX/GAM/src/gam/gapi/directory/__init__.py", line 5, in build
    return gam.buildGAPIObject('directory')
  File "/PREFIX/GAM/src/gam/__init__.py", line 965, in buildGAPIObject
    service = getService(api, http)
  File "/PREFIX/GAM/src/gam/__init__.py", line 911, in getService
    service = googleapiclient.discovery.build(
  File "/PREFIX/site-packages/googleapiclient/_helpers.py", line 130, in positional_wrapper
    return wrapped(*args, **kwargs)
TypeError: build() got an unexpected keyword argument 'static_discovery'
```