### PR TITLE
Added support for `localfile -` in `gam <UserTypeEntity> create|update drivefile`

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -685,7 +685,7 @@ Specify a collection of Users by directly specifying them or by specifiying item
 	(name <String>)
 
 <DriveFileAddAttribute> ::=
-	(localfile <FileName>)|
+	(localfile <FileName>|-)|
 	(convert)|(ocr)|(ocrlanguage <Language>)|
 	(restricted|restrict)|(starred|star)|(trashed|trash)|(viewed|view)|
 	(contentrestrictions readonly false)|
@@ -695,7 +695,7 @@ Specify a collection of Users by directly specifying them or by specifiying item
 	(parentid <DriveFolderID>)|(parentname <DriveFolderName>)|(anyownerparentname <DriveFolderName>)|writerscantshare|writerscanshare
 	(shortcut <DriveFileID>)
 <DriveFileUpdateAttribute> ::=
-	(localfile <FileName>)|
+	(localfile <FileName>|-)|
 	(convert)|(ocr)|(ocrlanguage <Language>)|
 	(restricted|restrict <Boolean>)|(starred|star <Boolean>)|(trashed|trash <Boolean>)|(viewed|view <Boolean>)|
 	(contentrestrictions readonly false)|


### PR DESCRIPTION

This allows commands/programs to output data to stdout which can then be uploaded to a Google Drive file.
```
generatedata | gam user user@domain.com create drivefile drivefilename test.csv localfile - mimetype gsheet
```