### PR TITLE
Fix tests with apiclient >= 2.1

### DIFF
--- a/src/gam/gapi/__init___test.py
+++ b/src/gam/gapi/__init___test.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from gam import SetGlobalVariables
 import gam.gapi as gapi
 from gam.gapi import errors
+import httplib2
 
 
 def create_http_error(status, reason, message):
@@ -21,10 +22,10 @@ def create_http_error(status, reason, message):
   Returns:
     googleapiclient.errors.HttpError
   """
-    response = {
+    response = httplib2.Response({
         'status': status,
         'content-type': 'application/json',
-    }
+    })
     content = {
         'error': {
             'code': status,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 cryptography
 distro; sys_platform == 'linux'
 filelock
-google-api-python-client==2.0.2
+google-api-python-client>=2.1
 google-auth-httplib2
 google-auth-oauthlib>=0.4.1
 google-auth>=1.11.2


### PR DESCRIPTION
error handling in google-api-python-client changed in version 2.1. I don't have full details on the why.  This patch should fix our tests and allow GAM to use the latest googleapiclient.