### PR TITLE
Fix page_args_in_body, update namespace handling in show chromepolicies

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -204,6 +204,7 @@ If an item contains spaces, it should be surrounded by ".
 <MaximumNumberOfSeats> ::= <Number>
 <MobileID> ::= <String>
 <Name> ::= <String>
+<Namespace> ::= <String>
 <NotificationID> ::= <String>
 <NumberOfSeats> ::= <Number>
 <OrgUnitID> ::= <String>
@@ -594,6 +595,7 @@ Items, separated by spaces, with spaces, commas or single quotes in the items th
 <MatterItemList> ::= "<MatterItem>(,<MatterItem>)*"
 <MembersFieldNameList> ::= "<MembersFieldName>(,<MembersFieldName>)*"
 <MobileList> ::= "<MobileId>(,<MobileId>)*"
+<NamespaceList> ::= "<Namespace>(,<Namespace)*"
 <OrgUnitList> ::= "<OrgUnitPath>(,<OrgUnitPath>)*"
 <PrinterIDList> ::= "<PrinterID>)(,<PrinterID>)*"
 <ProductIDList> ::= "(<ProductID>|SKUID>)(,<ProductID>|SKUID>)*"
@@ -1313,7 +1315,7 @@ gam print chromehistory releases [todrive]
 
 gam delete chromepolicy <SchemaName>+ ou|org|orgunit <OrgUnitItem> [(printerid <PrinterID>)|(appid <AppID>)]
 gam update chromepolicy (<SchemaName> (<Field> <Value>)+)+ ou|org|orgunit <OrgUnitItem> [(printerid <PrinterID>)|(appid <AppID>)]
-gam show chromepolicy ou|org|orgunit <OrgUnitItem> [(printerid <PrinterID>)|(appid <AppID>)]
+gam show chromepolicy ou|org|orgunit <OrgUnitItem> [(printerid <PrinterID>)|(appid <AppID>)] [namespace <NamespaceList>]
 gam show chromeschema [filter <String>]
 
 <DeviceID> ::= devices/<String>

--- a/src/gam/gapi/__init__.py
+++ b/src/gam/gapi/__init__.py
@@ -319,11 +319,12 @@ def get_all_pages(service,
   Returns:
     A list of all items received from all paged responses.
   """
+    if page_args_in_body:
+        kwargs.setdefault('body', {})
     if 'maxResults' not in kwargs and 'pageSize' not in kwargs and 'pageSize' not in kwargs.get('body', {}):
         page_key = _get_max_page_size_for_api_call(service, function, **kwargs)
         if page_key:
             if page_args_in_body:
-                kwargs['body'] = kwargs.get('body', {})
                 kwargs['body'].update(page_key)
             else:
                 kwargs.update(page_key)

--- a/src/gam/gapi/chromepolicy.py
+++ b/src/gam/gapi/chromepolicy.py
@@ -54,7 +54,7 @@ def printshow_policies():
             app_id = sys.argv[i+1]
             i += 2
         elif myarg == 'namespace':
-            namespaces.append(sys.argv[i+1])
+            namespaces.extend(sys.argv[i+1].replace(',', ' ').split())
             i += 2
         else:
             msg = f'{myarg} is not a valid argument to "gam print chromepolicy"'
@@ -64,13 +64,15 @@ def printshow_policies():
     body['policyTargetKey'] = {'targetResource': orgunit}
     if printer_id:
         body['policyTargetKey']['additionalTargetKeys'] = {'printer_id': printer_id}
-        namespaces = ['chrome.printers']
+        if not namespaces:
+            namespaces = ['chrome.printers']
     elif app_id:
         body['policyTargetKey']['additionalTargetKeys'] = {'app_id': app_id}
-        namespaces = ['chrome.users.apps',
-                      'chrome.devices.managedGuest.apps',
-                      'chrome.devices.kiosk.apps']
-    if not namespaces:
+        if not namespaces:
+            namespaces = ['chrome.users.apps',
+                          'chrome.devices.managedGuest.apps',
+                          'chrome.devices.kiosk.apps']
+    elif not namespaces:
         namespaces = [
             'chrome.users',
             'chrome.users.apps',


### PR DESCRIPTION
When page_args_in_body is true you have to add body to kwargs to ensure a place for pageToken

Allow setting a list of namespaces that override the defaults for printerid (not likely) and appid.