### PR TITLE
Fix pip license error + add pip install command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,46 @@
 GAM is a command line tool for Google Workspace (fka G Suite) Administrators to manage domain and user settings quickly and easily.
 
 ![Build Status](https://github.com/jay0lee/GAM/workflows/Build%20and%20test%20GAM/badge.svg)
+
 # Quick Start
+
 ## Linux / MacOS
+
 Open a terminal and run:
-```
+
+```sh
 bash <(curl -s -S -L https://git.io/install-gam)
 ```
+
 this will download GAM, install it and start setup.
+
+To install with `pip`, run
+
+```sh
+pip install git+https://github.com/jay0lee/GAM.git#subdirectory=src
+```
+
+This will only download and install GAM. To start setup, simply invoke the `gam` CLI.
+
 ## Windows
+
 Download the MSI Installer from the [GitHub Releases] page. Install the MSI and you'll be prompted to setup GAM.
+
 # Documentation
+
 The GAM documentation is hosted in the [GitHub Wiki]
+
 # Mailing List / Discussion group
+
 The GAM mailing list / discussion group is hosted on [Google Groups].  You can join the list and interact via email, or just post from the web itself.
+
 # Chat Room
+
 There is a public chat room hosted in Google Chat. [Instructions to join](https://git.io/gam-chat).
+
 # Author
-GAM is maintained by <a href="mailto:jay0lee@gmail.com">Jay Lee</a>. Please direct "how do I?" questions to [Google Groups].
+
+GAM is maintained by [Jay Lee](mailto:jay0lee@gmail.com). Please direct "how do I?" questions to [Google Groups].
 
 [GAM release]: https://git.io/gamreleases
 [GitHub Releases]: https://github.com/jay0lee/GAM/releases

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/jay0lee/GAM
 author = Jay Lee
 author_email = jay0lee@gmail.com
 license = Apache
-license_file = LICENSE
+license_files = LICENSE
 keywords = google, oauth2, gsuite, google-apps, google-admin-sdk, google-drive, google-cloud, google-calendar, gam, google-api, oauth2-client, google-workspace
 classifiers =
     Programming Language :: Python :: 3

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/jay0lee/GAM
 author = Jay Lee
 author_email = jay0lee@gmail.com
 license = Apache
-license_file = src/license.rtf
+license_file = LICENSE
 keywords = google, oauth2, gsuite, google-apps, google-admin-sdk, google-drive, google-cloud, google-calendar, gam, google-api, oauth2-client, google-workspace
 classifiers =
     Programming Language :: Python :: 3


### PR DESCRIPTION
As a follow-up to #1417, this should fix the [pip license error](https://github.com/jay0lee/GAM/pull/1417#issuecomment-907418598) and inform users through the readme that GAM can now be installed with `pip`.

Closes #720.