### PR TITLE
Fix show filelist query issue; add driveId to drive file fields 

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -327,6 +327,7 @@ If an item contains spaces, it should be surrounded by ".
 	description|
 	editable|
 	explicitlytrashed|
+	driveid|
 	fileextension|
 	filesize|
 	foldercolorrgb|

--- a/src/gam/__init__.py
+++ b/src/gam/__init__.py
@@ -3273,7 +3273,7 @@ def printDriveFileList(users):
                     'orderby', ', '.join(sorted(DRIVEFILE_ORDERBY_CHOICES_MAP)),
                     fieldName)
         elif myarg == 'query':
-            query += f' and {sys.argv[i+1]}'
+            query += f' and ({sys.argv[i+1]})'
             i += 2
         elif myarg == 'fullquery':
             query = sys.argv[i + 1]

--- a/src/gam/var.py
+++ b/src/gam/var.py
@@ -458,6 +458,7 @@ DRIVEFILE_FIELDS_CHOICES_MAP = {
     'createddate': 'createdDate',
     'createdtime': 'createdDate',
     'description': 'description',
+    'driveid': 'driveId',
     'editable': 'editable',
     'explicitlytrashed': 'explicitlyTrashed',
     'fileextension': 'fileExtension',


### PR DESCRIPTION
If the user says: query "A or B" this becomes "'me' in owners and A or B" which is the same as "('me' in owners and A) or B" which gives incorrect results. The fix makes "'me' in owners and (A or B)"